### PR TITLE
Rewrite Dex-domain anchors to same-origin paths for Pages deploys

### DIFF
--- a/index.html
+++ b/index.html
@@ -522,7 +522,7 @@ body {
     >
       
         <div id="floatingCart" class="floating-cart hidden">
-          <a href="https://dexdsl.org/cart" class="icon icon--stroke icon--fill icon--cart sqs-custom-cart">
+          <a href="/dexdsl-site/cart" class="icon icon--stroke icon--fill icon--cart sqs-custom-cart">
             <span class="Cart-inner">
               
 
@@ -1086,7 +1086,7 @@ body {
   
     <div class="header-nav-item header-nav-item--collection">
       <a
-        href="https://dexdsl.org/catalog"
+        href="/dexdsl-site/catalog"
         data-animation-role="header-element"
         
       >
@@ -1101,7 +1101,7 @@ body {
   
     <div class="header-nav-item header-nav-item--collection">
       <a
-        href="https://dexdsl.org/call"
+        href="/dexdsl-site/call"
         data-animation-role="header-element"
         
       >
@@ -1116,7 +1116,7 @@ body {
   
     <div class="header-nav-item header-nav-item--collection">
       <a
-        href="https://dexdsl.org/dexnotes"
+        href="/dexdsl-site/dexnotes"
         data-animation-role="header-element"
         
       >
@@ -1131,7 +1131,7 @@ body {
   
     <div class="header-nav-item header-nav-item--collection">
       <a
-        href="https://dexdsl.org/about"
+        href="/dexdsl-site/about"
         data-animation-role="header-element"
         
       >
@@ -1188,7 +1188,7 @@ body {
                 <div class="header-actions-action header-actions-action--cta" data-animation-role="header-element">
                   <a
                     class="btn btn--border theme-btn--primary-inverse sqs-button-element--primary"
-                    href="https://dexdsl.org/donate"
+                    href="/dexdsl-site/donate"
                     
                   >
                     DOONATE
@@ -1312,7 +1312,7 @@ body {
                 <div class="header-actions-action header-actions-action--cta" data-animation-role="header-element">
                   <a
                     class="btn btn--border theme-btn--primary-inverse sqs-button-element--primary"
-                    href="https://dexdsl.org/donate"
+                    href="/dexdsl-site/donate"
                     
                   >
                     DOONATE
@@ -1364,7 +1364,7 @@ body {
   
     <div class="header-nav-item header-nav-item--collection">
       <a
-        href="https://dexdsl.org/catalog"
+        href="/dexdsl-site/catalog"
         data-animation-role="header-element"
         
       >
@@ -1379,7 +1379,7 @@ body {
   
     <div class="header-nav-item header-nav-item--collection">
       <a
-        href="https://dexdsl.org/call"
+        href="/dexdsl-site/call"
         data-animation-role="header-element"
         
       >
@@ -1394,7 +1394,7 @@ body {
   
     <div class="header-nav-item header-nav-item--collection">
       <a
-        href="https://dexdsl.org/dexnotes"
+        href="/dexdsl-site/dexnotes"
         data-animation-role="header-element"
         
       >
@@ -1409,7 +1409,7 @@ body {
   
     <div class="header-nav-item header-nav-item--collection">
       <a
-        href="https://dexdsl.org/about"
+        href="/dexdsl-site/about"
         data-animation-role="header-element"
         
       >
@@ -1701,7 +1701,7 @@ body {
           
             <div class="container header-menu-nav-item header-menu-nav-item--collection">
               <a
-                href="https://dexdsl.org/catalog"
+                href="/dexdsl-site/catalog"
                 
               >
                 <div class="header-menu-nav-item-content">
@@ -1718,7 +1718,7 @@ body {
           
             <div class="container header-menu-nav-item header-menu-nav-item--collection">
               <a
-                href="https://dexdsl.org/call"
+                href="/dexdsl-site/call"
                 
               >
                 <div class="header-menu-nav-item-content">
@@ -1735,7 +1735,7 @@ body {
           
             <div class="container header-menu-nav-item header-menu-nav-item--collection">
               <a
-                href="https://dexdsl.org/dexnotes"
+                href="/dexdsl-site/dexnotes"
                 
               >
                 <div class="header-menu-nav-item-content">
@@ -1752,7 +1752,7 @@ body {
           
             <div class="container header-menu-nav-item header-menu-nav-item--collection">
               <a
-                href="https://dexdsl.org/about"
+                href="/dexdsl-site/about"
                 
               >
                 <div class="header-menu-nav-item-content">
@@ -1826,7 +1826,7 @@ body {
             <div class="header-menu-cta">
               <a
                 class="theme-btn--primary btn sqs-button-element--primary"
-                href="https://dexdsl.org/donate"
+                href="/dexdsl-site/donate"
                 
               >
                 DOONATE
@@ -2263,7 +2263,7 @@ document.addEventListener('DOMContentLoaded', function(){
       </p>
       <div style="display:flex;flex-direction:column;gap:1rem;margin-top:1.5rem;">
         <a id="heroExplore"
-   href="https://dexdsl.org/catalog"
+   href="/dexdsl-site/catalog"
    class="sqs-button-element--primary sqs-block-button-element--large"
    style="display:inline-flex;align-items:center;justify-content:center;padding:.75em 1.6em;">
   <script>document.write(randomizeTitle("EXPLORE CATALOG"))</script>
@@ -3475,7 +3475,7 @@ footer.dex-footer { position:relative; z-index:1; isolation:isolate; }
   
     <!-- Dex /board PROMO — White-Opal, 4px radius, no filters, GSAP entrance -->
 <section id="dex-board-promo" class="dex-board-promo" data-context="home" role="region" aria-labelledby="dex-board-promo-title">
-  <a class="promo-surface" href="https://dexdsl.org/board" aria-label="Go to Dex /board">
+  <a class="promo-surface" href="/dexdsl-site/board" aria-label="Go to Dex /board">
     <div class="promo-grid">
 
       <!-- 1) Narrative -->
@@ -4397,9 +4397,9 @@ Dex 2.0 • SIGN-UP FOR FR‎E‎E AC‎C‎E‎SS  (Squarespace code-block)
   <header class="hdr card-like">
     <h2 id="dex-faq-head" class="p1">FAQ</h2>
     <nav class="faq-cta">
-      <a id="btn-catalog" href="https://dexdsl.org/catalog" class="ghost" data-label="Explore Our Catalog">Explore Our Catalog</a>
+      <a id="btn-catalog" href="/dexdsl-site/catalog" class="ghost" data-label="Explore Our Catalog">Explore Our Catalog</a>
       <!-- SQS primary button classes added; keep .cta for local styling -->
-      <a id="btn-call" href="https://dexdsl.org/call"
+      <a id="btn-call" href="/dexdsl-site/call"
          class="cta sqs-button-element sqs-button-element--primary sqs-block-button-element sqs-block-button-element--primary"
          data-label="Submit Your Work">Submit Your Work</a>
     </nav>
@@ -5083,9 +5083,9 @@ Dex 2.0 • SIGN-UP FOR FR‎E‎E AC‎C‎E‎SS  (Squarespace code-block)
         </a>
       </div>
       <nav class="footer-nav">
-        <a href="https://dexdsl.org/privacy">Privacy</a>
-        <a href="https://dexdsl.org/contact">Contact</a>
-        <a href="https://dexdsl.org/copyright">Copyright</a>
+        <a href="/dexdsl-site/privacy">Privacy</a>
+        <a href="/dexdsl-site/contact">Contact</a>
+        <a href="/dexdsl-site/copyright">Copyright</a>
       </nav>
     </div>
   </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,39 @@
+{
+  "name": "dex-web-home",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "dex-web-home",
+      "devDependencies": {
+        "parse5": "^7.3.0"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "dex-web-home",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "rewrite:anchors": "node scripts/rewrite-internal-anchors.mjs",
+    "check:anchors": "node scripts/rewrite-internal-anchors.mjs --check"
+  },
+  "devDependencies": {
+    "parse5": "^7.3.0"
+  }
+}

--- a/scripts/rewrite-internal-anchors.mjs
+++ b/scripts/rewrite-internal-anchors.mjs
@@ -1,0 +1,187 @@
+#!/usr/bin/env node
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { parse } from 'parse5';
+
+const TARGET_HOSTNAMES = new Set([
+  'dexdsl.org',
+  'www.dexdsl.org',
+  'dexdsl.com',
+  'www.dexdsl.com',
+]);
+
+const PUBLISH_DIR = process.env.PUBLISH_DIR
+  ? path.resolve(process.env.PUBLISH_DIR)
+  : process.cwd();
+
+const isCheckMode = process.argv.includes('--check');
+
+function normalizeBase(base) {
+  if (!base || base === '/') return '';
+
+  let normalized = base.trim();
+  if (!normalized.startsWith('/')) {
+    normalized = `/${normalized}`;
+  }
+
+  normalized = normalized.replace(/\/+$/, '');
+  return normalized === '/' ? '' : normalized;
+}
+
+function deriveDefaultBasePath() {
+  const explicit = process.env.BASE_PATH;
+  if (typeof explicit === 'string') {
+    return normalizeBase(explicit);
+  }
+
+  const repo = process.env.GITHUB_REPOSITORY?.split('/')[1] ?? '';
+  if (!repo) return '';
+  if (repo.toLowerCase().endsWith('.github.io')) return '';
+  return normalizeBase(`/${repo}`);
+}
+
+function isSupportedHref(href) {
+  if (!href) return false;
+  const lowered = href.trim().toLowerCase();
+  if (!lowered) return false;
+
+  if (
+    lowered.startsWith('mailto:') ||
+    lowered.startsWith('tel:') ||
+    lowered.startsWith('javascript:') ||
+    lowered.startsWith('data:')
+  ) {
+    return false;
+  }
+
+  return (
+    lowered.startsWith('http://') ||
+    lowered.startsWith('https://') ||
+    lowered.startsWith('//')
+  );
+}
+
+function getReplacementHref(href, basePath) {
+  if (!isSupportedHref(href)) return null;
+
+  let url;
+  try {
+    url = new URL(href, 'https://dexdsl.org');
+  } catch {
+    return null;
+  }
+
+  if (!TARGET_HOSTNAMES.has(url.hostname.toLowerCase())) return null;
+  if (!(url.protocol === 'http:' || url.protocol === 'https:')) return null;
+
+  const pathAndSuffix = `${url.pathname}${url.search}${url.hash}`;
+  return basePath ? `${basePath}${pathAndSuffix}` : pathAndSuffix;
+}
+
+async function collectHtmlFiles(rootDir) {
+  const files = [];
+
+  async function walk(currentDir) {
+    const entries = await fs.readdir(currentDir, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = path.join(currentDir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === '.git' || entry.name === 'node_modules') continue;
+        await walk(fullPath);
+      } else if (entry.isFile() && entry.name.toLowerCase().endsWith('.html')) {
+        files.push(fullPath);
+      }
+    }
+  }
+
+  await walk(rootDir);
+  return files;
+}
+
+function gatherReplacements(html, basePath) {
+  const document = parse(html, { sourceCodeLocationInfo: true });
+  const replacements = [];
+
+  function visit(node) {
+    if (!node || typeof node !== 'object') return;
+
+    if ((node.nodeName === 'a' || node.nodeName === 'area') && node.attrs && node.sourceCodeLocation?.attrs?.href) {
+      const hrefAttr = node.attrs.find((attr) => attr.name === 'href');
+      if (hrefAttr) {
+        const replacementHref = getReplacementHref(hrefAttr.value, basePath);
+        if (replacementHref && replacementHref !== hrefAttr.value) {
+          const loc = node.sourceCodeLocation.attrs.href;
+          replacements.push({
+            startOffset: loc.startOffset,
+            endOffset: loc.endOffset,
+            text: `href="${replacementHref}"`,
+          });
+        }
+      }
+    }
+
+    if (node.childNodes) {
+      for (const child of node.childNodes) {
+        visit(child);
+      }
+    }
+  }
+
+  visit(document);
+  return replacements;
+}
+
+function applyReplacements(content, replacements) {
+  if (replacements.length === 0) return content;
+
+  const ordered = [...replacements].sort((a, b) => b.startOffset - a.startOffset);
+  let updated = content;
+  for (const replacement of ordered) {
+    updated =
+      updated.slice(0, replacement.startOffset) +
+      replacement.text +
+      updated.slice(replacement.endOffset);
+  }
+  return updated;
+}
+
+async function processFile(filePath, basePath, checkMode) {
+  const original = await fs.readFile(filePath, 'utf8');
+  const replacements = gatherReplacements(original, basePath);
+
+  if (!checkMode && replacements.length > 0) {
+    const updated = applyReplacements(original, replacements);
+    if (updated !== original) {
+      await fs.writeFile(filePath, updated, 'utf8');
+    }
+  }
+
+  return replacements.length;
+}
+
+async function main() {
+  const basePath = deriveDefaultBasePath();
+  const htmlFiles = await collectHtmlFiles(PUBLISH_DIR);
+
+  if (htmlFiles.length === 0) {
+    console.error(`No HTML files found in ${PUBLISH_DIR}`);
+    process.exit(1);
+  }
+
+  let total = 0;
+  for (const filePath of htmlFiles) {
+    const count = await processFile(filePath, basePath, isCheckMode);
+    total += count;
+    console.log(`${path.relative(PUBLISH_DIR, filePath)}: ${count}`);
+  }
+
+  if (isCheckMode && total > 0) {
+    console.error(`Check failed: found ${total} link(s) requiring rewrite.`);
+    process.exit(1);
+  }
+
+  console.log(`Total ${isCheckMode ? 'matches' : 'rewrites'}: ${total}`);
+}
+
+await main();


### PR DESCRIPTION
### Motivation
- The Squarespace-exported site used absolute links to dexdsl.org/.com which caused navigation to leave GitHub Pages staging sites. 
- We need a deterministic build-time rewrite so internal nav anchors become same-origin paths under a configurable base (e.g. `/dexdsl-site`) without affecting non-nav assets or external links.

### Description
- Add `scripts/rewrite-internal-anchors.mjs`, a Node script that recursively scans `*.html` and rewrites only `<a href>` and `<area href>` values that target `dexdsl.org`/`www.dexdsl.org`/`dexdsl.com`/`www.dexdsl.com` to `${BASE}${pathname}${search}${hash}` while preserving path/query/hash exactly. 
- The script ignores `mailto:`, `tel:`, `javascript:`, `data:` and non-anchor attributes, treats protocol-relative `//` and absolute `http(s)` links, and uses safe HTML source-location edits to avoid reformatting. 
- Supports default `BASE_PATH` inference from `process.env.BASE_PATH` or `GITHUB_REPOSITORY` (project pages => `/<repo>`, org/user pages => `""`), normalizes base (leading slash, no trailing slash), and provides an idempotent `--check` mode that fails when matches remain. 
- Add `package.json` npm scripts `rewrite:anchors` and `check:anchors` and the lockfile/devDependency used during development, and apply rewritten anchors in `index.html` for staging paths (e.g. `/dexdsl-site/...`).

### Testing
- Ran `npm ci` successfully to install dev deps. 
- Ran `BASE_PATH="/dexdsl-site" npm run rewrite:anchors` which reported rewrites (e.g. `index.html: 23`, `hero.html: 0`) and then re-ran it to confirm idempotence (second run produced `0` rewrites). 
- Ran `npm run check:anchors --` (script uses `--check`) which returned no remaining matches and exited zero. 
- Performed a local visual smoke check by serving the site with `python3 -m http.server` and capturing a browser screenshot to verify navigation UI; the commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997a10fcf3883279ef6017fa7dc1ab8)