### PR TITLE
Add Auth0 SPA login guards, header auth UI, and protected-route stubs

### DIFF
--- a/assets/dex-auth.js
+++ b/assets/dex-auth.js
@@ -1,0 +1,368 @@
+(function () {
+  "use strict";
+
+  var AUTH_UI_ID = "auth-ui";
+  var DROPDOWN_OPEN_CLASS = "is-open";
+  var PROTECTED_PATHS = {
+    "/press": true,
+    "/entry/2-organs-midori-ataka": true,
+    "/entry/aidan-yeats": true,
+    "/entry/amplified-knives-tyler-jordan": true,
+    "/entry/amplified-printer": true,
+    "/entry/amplified-tv-sam-pluta": true,
+    "/entry/anant-shah": true,
+    "/entry/andrew-chanover": true,
+    "/entry/as-though-im-slipping": true,
+    "/entry/bassoon-and-electronics": true,
+    "/entry/bojun-zhang": true,
+    "/entry/cello-emmanuel-losa": true,
+    "/entry/cybernetic-scat-paul-hermansen": true,
+    "/entry/electric-guitar-chris-mann": true,
+    "/entry/electric-guitar-pedals-ethan-bailey-gould": true,
+    "/entry/hammered-dulcimer-cameron-church": true,
+    "/entry/multiperc": true,
+    "/entry/no-input-mixer-jared-murphy": true,
+    "/entry/prepared-bass-viol-suarez-solis": true,
+    "/entry/prepared-harpsichord-suarez-solis": true,
+    "/entry/prepared-oboe-sky-macklay": true,
+    "/entry/sebastian-suarez-solis": true,
+    "/entry/splinterings-jakob-heinemann": true,
+    "/entry/this-is-a-tangible-space": true,
+    "/entry/tim-feeney": true,
+    "/entry/voice-everyday-object-manipulation-levi-lu": true
+  };
+
+  var authClient = null;
+  var isAuthenticated = false;
+
+  function logError() {
+    var args = Array.prototype.slice.call(arguments);
+    args.unshift("[dex-auth]");
+    console.error.apply(console, args);
+  }
+
+  function normalizePath(pathname) {
+    var path = pathname || "/";
+    if (typeof path !== "string") {
+      path = String(path || "/");
+    }
+    if (!path) {
+      return "/";
+    }
+    if (path.charAt(0) !== "/") {
+      path = "/" + path;
+    }
+    path = path.replace(/\/+/g, "/");
+    if (path.length > 1 && path.charAt(path.length - 1) === "/") {
+      path = path.slice(0, -1);
+    }
+    return path || "/";
+  }
+
+  function isProtectedPath(pathname) {
+    return !!PROTECTED_PATHS[normalizePath(pathname)];
+  }
+
+  function isCallbackPath(pathname) {
+    return normalizePath(pathname).indexOf("/auth/callback") === 0;
+  }
+
+  function getReturnToFromUrl(urlObj) {
+    return (urlObj.pathname || "/") + (urlObj.search || "") + (urlObj.hash || "");
+  }
+
+  function hideLegacyAccountUi() {
+    var nodes = document.querySelectorAll(
+      ".customerAccountLoginDesktop, .customerAccountLoginMobile, [data-controller='UserAccountLink']"
+    );
+    for (var i = 0; i < nodes.length; i += 1) {
+      nodes[i].style.display = "none";
+    }
+  }
+
+  function ensureAuthUi() {
+    if (document.getElementById(AUTH_UI_ID)) {
+      return document.getElementById(AUTH_UI_ID);
+    }
+
+    hideLegacyAccountUi();
+
+    var styleId = "dex-auth-style";
+    if (!document.getElementById(styleId)) {
+      var style = document.createElement("style");
+      style.id = styleId;
+      style.textContent = ""
+        + "#auth-ui{position:relative;display:inline-flex;align-items:center;gap:10px;font-family:inherit;}"
+        + "#auth-ui [hidden]{display:none!important;}"
+        + "#auth-ui-signin{padding:8px 12px;border:1px solid #111;background:#fff;color:#111;cursor:pointer;font-size:12px;letter-spacing:.08em;text-transform:uppercase;}"
+        + "#auth-ui-profile-toggle{display:inline-flex;align-items:center;justify-content:center;border:1px solid #d4d4d4;background:#fff;width:36px;height:36px;border-radius:9999px;cursor:pointer;padding:0;}"
+        + "#auth-ui-avatar{width:100%;height:100%;border-radius:9999px;object-fit:cover;display:block;}"
+        + "#auth-ui-dropdown{position:absolute;right:0;top:calc(100% + 8px);min-width:160px;border:1px solid #ddd;background:#fff;box-shadow:0 8px 24px rgba(0,0,0,.12);padding:8px;z-index:9999;display:none;}"
+        + "#auth-ui-dropdown." + DROPDOWN_OPEN_CLASS + "{display:block;}"
+        + "#auth-ui-logout{width:100%;border:1px solid #111;background:#fff;padding:8px 10px;cursor:pointer;font-size:12px;letter-spacing:.08em;text-transform:uppercase;}";
+      document.head.appendChild(style);
+    }
+
+    var ui = document.createElement("div");
+    ui.id = AUTH_UI_ID;
+    ui.innerHTML = ""
+      + '<button id="auth-ui-signin" type="button">SIGN IN</button>'
+      + '<div id="auth-ui-profile" hidden>'
+      + '  <button id="auth-ui-profile-toggle" type="button" aria-haspopup="true" aria-expanded="false" title="Profile">'
+      + '    <img id="auth-ui-avatar" alt="Profile avatar" src="data:image/gif;base64,R0lGODlhAQABAAAAACw=">'
+      + "  </button>"
+      + '  <div id="auth-ui-dropdown" role="menu">'
+      + '    <button id="auth-ui-logout" type="button">Log out</button>'
+      + "  </div>"
+      + "</div>";
+
+    var mount = document.querySelector(".header-actions--right") ||
+      document.querySelector(".header-actions") ||
+      document.querySelector("header") ||
+      document.body;
+    mount.appendChild(ui);
+    return ui;
+  }
+
+  function setUiState(auth, user) {
+    var ui = ensureAuthUi();
+    if (!ui) {
+      return;
+    }
+    var signInBtn = document.getElementById("auth-ui-signin");
+    var profileWrap = document.getElementById("auth-ui-profile");
+    var profileToggle = document.getElementById("auth-ui-profile-toggle");
+    var avatar = document.getElementById("auth-ui-avatar");
+
+    if (!signInBtn || !profileWrap || !profileToggle || !avatar) {
+      return;
+    }
+
+    if (auth) {
+      signInBtn.hidden = true;
+      profileWrap.hidden = false;
+      if (user && user.picture) {
+        avatar.src = user.picture;
+      }
+      if (user && user.name) {
+        profileToggle.title = user.name;
+      }
+    } else {
+      signInBtn.hidden = false;
+      profileWrap.hidden = true;
+    }
+  }
+
+  function closeDropdown() {
+    var menu = document.getElementById("auth-ui-dropdown");
+    var toggle = document.getElementById("auth-ui-profile-toggle");
+    if (menu) {
+      menu.classList.remove(DROPDOWN_OPEN_CLASS);
+    }
+    if (toggle) {
+      toggle.setAttribute("aria-expanded", "false");
+    }
+  }
+
+  function bindUiEvents() {
+    var signInBtn = document.getElementById("auth-ui-signin");
+    var profileWrap = document.getElementById("auth-ui-profile");
+    var profileToggle = document.getElementById("auth-ui-profile-toggle");
+    var logoutBtn = document.getElementById("auth-ui-logout");
+    var dropdown = document.getElementById("auth-ui-dropdown");
+
+    if (signInBtn && !signInBtn.dataset.bound) {
+      signInBtn.dataset.bound = "1";
+      signInBtn.addEventListener("click", function () {
+        if (!authClient) {
+          logError("Auth client unavailable for sign in.");
+          return;
+        }
+        authClient.loginWithRedirect({
+          appState: { returnTo: window.location.pathname + window.location.search + window.location.hash }
+        }).catch(function (err) {
+          logError("loginWithRedirect failed:", err);
+        });
+      });
+    }
+
+    if (profileToggle && !profileToggle.dataset.bound) {
+      profileToggle.dataset.bound = "1";
+      profileToggle.addEventListener("click", function (evt) {
+        evt.preventDefault();
+        if (!dropdown) {
+          return;
+        }
+        var open = dropdown.classList.toggle(DROPDOWN_OPEN_CLASS);
+        profileToggle.setAttribute("aria-expanded", open ? "true" : "false");
+      });
+    }
+
+    if (logoutBtn && !logoutBtn.dataset.bound) {
+      logoutBtn.dataset.bound = "1";
+      logoutBtn.addEventListener("click", function () {
+        if (!authClient) {
+          logError("Auth client unavailable for logout.");
+          return;
+        }
+        authClient.logout({
+          logoutParams: {
+            returnTo: window.location.origin
+          }
+        });
+      });
+    }
+
+    if (!document.documentElement.dataset.dexAuthOutsideBound) {
+      document.documentElement.dataset.dexAuthOutsideBound = "1";
+      document.addEventListener("click", function (evt) {
+        if (!profileWrap || profileWrap.hidden) {
+          return;
+        }
+        var inside = profileWrap.contains(evt.target);
+        if (!inside) {
+          closeDropdown();
+        }
+      });
+    }
+  }
+
+  function parseAnchorFromClick(target) {
+    var node = target;
+    while (node && node !== document.documentElement) {
+      if (node.tagName && node.tagName.toLowerCase() === "a") {
+        return node;
+      }
+      node = node.parentNode;
+    }
+    return null;
+  }
+
+  function handleGuardedNavIntent(returnTo) {
+    if (!authClient) {
+      logError("Auth client unavailable for route guard redirect.");
+      return;
+    }
+    authClient.loginWithRedirect({
+      appState: { returnTo: returnTo }
+    }).catch(function (err) {
+      logError("loginWithRedirect failed:", err);
+    });
+  }
+
+  function bindClickGuard() {
+    if (document.documentElement.dataset.dexAuthClickGuardBound) {
+      return;
+    }
+    document.documentElement.dataset.dexAuthClickGuardBound = "1";
+
+    document.addEventListener("click", function (evt) {
+      try {
+        var anchor = parseAnchorFromClick(evt.target);
+        if (!anchor) {
+          return;
+        }
+        var href = anchor.getAttribute("href");
+        if (!href || href.charAt(0) === "#") {
+          return;
+        }
+        var url = new URL(anchor.href, window.location.href);
+        if (url.origin !== window.location.origin) {
+          return;
+        }
+        if (!isProtectedPath(url.pathname)) {
+          return;
+        }
+        if (isAuthenticated) {
+          return;
+        }
+        evt.preventDefault();
+        evt.stopPropagation();
+        handleGuardedNavIntent(getReturnToFromUrl(url));
+      } catch (err) {
+        logError("Failed while guarding clicked link:", err);
+      }
+    }, true);
+  }
+
+  function clearAuthQueryParams() {
+    var url = new URL(window.location.href);
+    if (!url.searchParams.has("code") && !url.searchParams.has("state")) {
+      return;
+    }
+    url.searchParams.delete("code");
+    url.searchParams.delete("state");
+    var cleaned = url.pathname + (url.search ? url.search : "") + (url.hash ? url.hash : "");
+    window.history.replaceState({}, document.title, cleaned);
+  }
+
+  function getCurrentReturnTo() {
+    return window.location.pathname + window.location.search + window.location.hash;
+  }
+
+  async function init() {
+    try {
+      var cfgRoot = window.DEX_AUTH0_CONFIG;
+      var cfg = cfgRoot && cfgRoot.current;
+      ensureAuthUi();
+      if (!cfg) {
+        logError("Missing host Auth0 configuration; auth features disabled.");
+        bindUiEvents();
+        bindClickGuard();
+        return;
+      }
+      if (typeof window.createAuth0Client !== "function") {
+        logError("Auth0 SPA SDK missing; expected createAuth0Client global.");
+        bindUiEvents();
+        bindClickGuard();
+        return;
+      }
+
+      var authorizationParams = {
+        redirect_uri: cfg.redirectUri,
+        scope: "openid profile email"
+      };
+      if (cfg.audience) {
+        authorizationParams.audience = cfg.audience;
+      }
+
+      authClient = await window.createAuth0Client({
+        domain: cfg.domain,
+        clientId: cfg.clientId,
+        authorizationParams: authorizationParams
+        // cacheLocation: "localstorage",
+        // useRefreshTokens: true
+      });
+
+      if (isCallbackPath(window.location.pathname)) {
+        var callbackResult = await authClient.handleRedirectCallback();
+        clearAuthQueryParams();
+        var returnTo = (callbackResult && callbackResult.appState && callbackResult.appState.returnTo) || "/";
+        window.location.replace(returnTo);
+        return;
+      }
+
+      isAuthenticated = await authClient.isAuthenticated();
+      if (isProtectedPath(window.location.pathname) && !isAuthenticated) {
+        handleGuardedNavIntent(getCurrentReturnTo());
+        return;
+      }
+
+      var user = null;
+      if (isAuthenticated) {
+        user = await authClient.getUser();
+      }
+      setUiState(isAuthenticated, user);
+      bindUiEvents();
+      bindClickGuard();
+    } catch (err) {
+      logError("Initialization error:", err);
+    }
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/assets/dex-auth0-config.js
+++ b/assets/dex-auth0-config.js
@@ -1,0 +1,33 @@
+(function () {
+  var host = window.location.hostname;
+  var byHost = {
+    "dexdsl.github.io": {
+      domain: "YOUR_AUTH0_DOMAIN",
+      clientId: "YOUR_AUTH0_CLIENT_ID",
+      audience: "",
+      redirectUri: "https://dexdsl.github.io/auth/callback/"
+    },
+    "dexdsl.org": {
+      domain: "YOUR_AUTH0_DOMAIN",
+      clientId: "YOUR_AUTH0_CLIENT_ID",
+      audience: "",
+      redirectUri: "https://dexdsl.org/auth/callback/"
+    },
+    "dexdsl.com": {
+      domain: "YOUR_AUTH0_DOMAIN",
+      clientId: "YOUR_AUTH0_CLIENT_ID",
+      audience: "",
+      redirectUri: "https://dexdsl.com/auth/callback/"
+    }
+  };
+
+  var config = byHost[host] || null;
+  if (!config) {
+    console.warn("[dex-auth] No Auth0 config found for host:", host);
+  }
+
+  window.DEX_AUTH0_CONFIG = {
+    byHost: byHost,
+    current: config
+  };
+})();

--- a/auth/callback/index.html
+++ b/auth/callback/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Dex — Signing in...</title>
+  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+  <script defer src="/assets/dex-auth0-config.js"></script>
+  <script defer src="/assets/dex-auth.js"></script>
+</head>
+<body style="font-family: Arial, sans-serif; margin: 2rem;">
+  <p>Signing you in…</p>
+</body>
+</html>

--- a/docs/about.html
+++ b/docs/about.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./about/">
 <link rel="canonical" href="./about/">
 <script>location.replace("./about/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/about/index.html
+++ b/docs/about/index.html
@@ -1010,7 +1010,11 @@ section[data-section-id="68aee0174ac4f563fc75d173"] :is(a,button,[role="tab"]):f
 </script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-68aee00f12b81f787a9d6e9c"

--- a/docs/achievements.html
+++ b/docs/achievements.html
@@ -473,7 +473,11 @@ html, body {
 <script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-6890044cb72a26270296c274"

--- a/docs/b2b.html
+++ b/docs/b2b.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./b2b/">
 <link rel="canonical" href="./b2b/">
 <script>location.replace("./b2b/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/b2b/index.html
+++ b/docs/b2b/index.html
@@ -465,7 +465,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-68a576453879ff01ca99118f"

--- a/docs/board.html
+++ b/docs/board.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./board/">
 <link rel="canonical" href="./board/">
 <script>location.replace("./board/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/board/index.html
+++ b/docs/board/index.html
@@ -1003,7 +1003,11 @@ section[data-section-id="68a6cd92d267576b7646e452"] :is(a,button,[role="tab"]):f
 </script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-68a6cd8812da8e410ed59ee0"

--- a/docs/call.html
+++ b/docs/call.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./call/">
 <link rel="canonical" href="./call/">
 <script>location.replace("./call/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/call/index.html
+++ b/docs/call/index.html
@@ -475,7 +475,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-64320a937ce1fd52def89da6"

--- a/docs/cart.html
+++ b/docs/cart.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./cart/">
 <link rel="canonical" href="./cart/">
 <script>location.replace("./cart/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/cart/index.html
+++ b/docs/cart/index.html
@@ -460,7 +460,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="cart"

--- a/docs/catalog.html
+++ b/docs/catalog.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./catalog/">
 <link rel="canonical" href="./catalog/">
 <script>location.replace("./catalog/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/catalog/index.html
+++ b/docs/catalog/index.html
@@ -485,7 +485,11 @@ function AutoScrollLayout(e){e=""==e?document.querySelector(".user-items-list-se
 </script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-64701a82a4f7b041d197ccc5"

--- a/docs/contact.html
+++ b/docs/contact.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./contact/">
 <link rel="canonical" href="./contact/">
 <script>location.replace("./contact/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/contact/index.html
+++ b/docs/contact/index.html
@@ -465,7 +465,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-639572db5ce8870456897e27"

--- a/docs/copyright.html
+++ b/docs/copyright.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./copyright/">
 <link rel="canonical" href="./copyright/">
 <script>location.replace("./copyright/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/copyright/index.html
+++ b/docs/copyright/index.html
@@ -465,7 +465,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-643a0e8cf61a73569d0d6c85"

--- a/docs/dex.html
+++ b/docs/dex.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./dex/">
 <link rel="canonical" href="./dex/">
 <script>location.replace("./dex/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dex/index.html
+++ b/docs/dex/index.html
@@ -465,7 +465,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-639572d38baa4967b393b17b"

--- a/docs/dexfest/2024/day1.html
+++ b/docs/dexfest/2024/day1.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./day1/">
 <link rel="canonical" href="./day1/">
 <script>location.replace("./day1/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexfest/2024/day1/index.html
+++ b/docs/dexfest/2024/day1/index.html
@@ -465,7 +465,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-66af3f842a9f552c12f51f32"

--- a/docs/dexnotes.html
+++ b/docs/dexnotes.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./dexnotes/">
 <link rel="canonical" href="./dexnotes/">
 <script>location.replace("./dexnotes/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/01.html
+++ b/docs/dexnotes/01.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./01/">
 <link rel="canonical" href="./01/">
 <script>location.replace("./01/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/01/index.html
+++ b/docs/dexnotes/01/index.html
@@ -482,7 +482,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="item-643b4a71f93ac8664352699b"

--- a/docs/dexnotes/02.html
+++ b/docs/dexnotes/02.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./02/">
 <link rel="canonical" href="./02/">
 <script>location.replace("./02/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/02/index.html
+++ b/docs/dexnotes/02/index.html
@@ -478,7 +478,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="item-6477e1678ef2b12d48168cd4"

--- a/docs/dexnotes/03.html
+++ b/docs/dexnotes/03.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./03/">
 <link rel="canonical" href="./03/">
 <script>location.replace("./03/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/03/index.html
+++ b/docs/dexnotes/03/index.html
@@ -478,7 +478,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="item-6477e656416d3b676be3bee9"

--- a/docs/dexnotes/04.html
+++ b/docs/dexnotes/04.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./04/">
 <link rel="canonical" href="./04/">
 <script>location.replace("./04/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/04/index.html
+++ b/docs/dexnotes/04/index.html
@@ -479,7 +479,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="item-6477f21c6b987d3367ccc21c"

--- a/docs/dexnotes/05.html
+++ b/docs/dexnotes/05.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./05/">
 <link rel="canonical" href="./05/">
 <script>location.replace("./05/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/05/index.html
+++ b/docs/dexnotes/05/index.html
@@ -478,7 +478,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="item-6477d3862647bd2eb73eeb7d"

--- a/docs/dexnotes/announcing-dexfest-2024.html
+++ b/docs/dexnotes/announcing-dexfest-2024.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./announcing-dexfest-2024/">
 <link rel="canonical" href="./announcing-dexfest-2024/">
 <script>location.replace("./announcing-dexfest-2024/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/announcing-dexfest-2024/index.html
+++ b/docs/dexnotes/announcing-dexfest-2024/index.html
@@ -480,7 +480,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="item-66f07fa6abdc0a173e0e0f4c"

--- a/docs/dexnotes/category/Edition+1.html
+++ b/docs/dexnotes/category/Edition+1.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./Edition+1/">
 <link rel="canonical" href="./Edition+1/">
 <script>location.replace("./Edition+1/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/category/Edition+1/index.html
+++ b/docs/dexnotes/category/Edition+1/index.html
@@ -466,7 +466,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-643287996266bb6c8e688f2b"

--- a/docs/dexnotes/category/Edition+2.html
+++ b/docs/dexnotes/category/Edition+2.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./Edition+2/">
 <link rel="canonical" href="./Edition+2/">
 <script>location.replace("./Edition+2/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/category/Edition+2/index.html
+++ b/docs/dexnotes/category/Edition+2/index.html
@@ -466,7 +466,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-643287996266bb6c8e688f2b"

--- a/docs/dexnotes/category/Edition+3.html
+++ b/docs/dexnotes/category/Edition+3.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./Edition+3/">
 <link rel="canonical" href="./Edition+3/">
 <script>location.replace("./Edition+3/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/category/Edition+3/index.html
+++ b/docs/dexnotes/category/Edition+3/index.html
@@ -466,7 +466,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-643287996266bb6c8e688f2b"

--- a/docs/dexnotes/category/Edition+4.html
+++ b/docs/dexnotes/category/Edition+4.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./Edition+4/">
 <link rel="canonical" href="./Edition+4/">
 <script>location.replace("./Edition+4/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/category/Edition+4/index.html
+++ b/docs/dexnotes/category/Edition+4/index.html
@@ -466,7 +466,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-643287996266bb6c8e688f2b"

--- a/docs/dexnotes/category/Edition+5.html
+++ b/docs/dexnotes/category/Edition+5.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./Edition+5/">
 <link rel="canonical" href="./Edition+5/">
 <script>location.replace("./Edition+5/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/category/Edition+5/index.html
+++ b/docs/dexnotes/category/Edition+5/index.html
@@ -466,7 +466,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-643287996266bb6c8e688f2b"

--- a/docs/dexnotes/category/Edition+6.html
+++ b/docs/dexnotes/category/Edition+6.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./Edition+6/">
 <link rel="canonical" href="./Edition+6/">
 <script>location.replace("./Edition+6/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/category/Edition+6/index.html
+++ b/docs/dexnotes/category/Edition+6/index.html
@@ -466,7 +466,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-643287996266bb6c8e688f2b"

--- a/docs/dexnotes/category/Edition+7.html
+++ b/docs/dexnotes/category/Edition+7.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./Edition+7/">
 <link rel="canonical" href="./Edition+7/">
 <script>location.replace("./Edition+7/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/category/Edition+7/index.html
+++ b/docs/dexnotes/category/Edition+7/index.html
@@ -466,7 +466,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-643287996266bb6c8e688f2b"

--- a/docs/dexnotes/category/Edition+8.html
+++ b/docs/dexnotes/category/Edition+8.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./Edition+8/">
 <link rel="canonical" href="./Edition+8/">
 <script>location.replace("./Edition+8/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/category/Edition+8/index.html
+++ b/docs/dexnotes/category/Edition+8/index.html
@@ -466,7 +466,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-643287996266bb6c8e688f2b"

--- a/docs/dexnotes/category/Edition+9.html
+++ b/docs/dexnotes/category/Edition+9.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./Edition+9/">
 <link rel="canonical" href="./Edition+9/">
 <script>location.replace("./Edition+9/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/category/Edition+9/index.html
+++ b/docs/dexnotes/category/Edition+9/index.html
@@ -466,7 +466,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-643287996266bb6c8e688f2b"

--- a/docs/dexnotes/category/Update.html
+++ b/docs/dexnotes/category/Update.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./Update/">
 <link rel="canonical" href="./Update/">
 <script>location.replace("./Update/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/category/Update/index.html
+++ b/docs/dexnotes/category/Update/index.html
@@ -466,7 +466,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-643287996266bb6c8e688f2b"

--- a/docs/dexnotes/dex-deux.html
+++ b/docs/dexnotes/dex-deux.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./dex-deux/">
 <link rel="canonical" href="./dex-deux/">
 <script>location.replace("./dex-deux/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/dex-deux/index.html
+++ b/docs/dexnotes/dex-deux/index.html
@@ -475,7 +475,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="item-661cb3a5b369d36c1b448264"

--- a/docs/dexnotes/gala.html
+++ b/docs/dexnotes/gala.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./gala/">
 <link rel="canonical" href="./gala/">
 <script>location.replace("./gala/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/gala/index.html
+++ b/docs/dexnotes/gala/index.html
@@ -477,7 +477,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="item-66689edc1bce9c1198c200fd"

--- a/docs/dexnotes/help-us-seat-dexs-founding-expansion-board.html
+++ b/docs/dexnotes/help-us-seat-dexs-founding-expansion-board.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./help-us-seat-dexs-founding-expansion-board/">
 <link rel="canonical" href="./help-us-seat-dexs-founding-expansion-board/">
 <script>location.replace("./help-us-seat-dexs-founding-expansion-board/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/help-us-seat-dexs-founding-expansion-board/index.html
+++ b/docs/dexnotes/help-us-seat-dexs-founding-expansion-board/index.html
@@ -480,7 +480,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="item-68aceac76bcbbe7713de0b12"

--- a/docs/dexnotes/index.html
+++ b/docs/dexnotes/index.html
@@ -466,7 +466,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-643287996266bb6c8e688f2b"

--- a/docs/dexnotes/japanensemble.html
+++ b/docs/dexnotes/japanensemble.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./japanensemble/">
 <link rel="canonical" href="./japanensemble/">
 <script>location.replace("./japanensemble/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/japanensemble/index.html
+++ b/docs/dexnotes/japanensemble/index.html
@@ -478,7 +478,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="item-661b6481d2900c362cc7bf9f"

--- a/docs/dexnotes/tag/Advisors.html
+++ b/docs/dexnotes/tag/Advisors.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./Advisors/">
 <link rel="canonical" href="./Advisors/">
 <script>location.replace("./Advisors/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/tag/Advisors/index.html
+++ b/docs/dexnotes/tag/Advisors/index.html
@@ -466,7 +466,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-643287996266bb6c8e688f2b"

--- a/docs/dexnotes/tag/Arts-Tech.html
+++ b/docs/dexnotes/tag/Arts-Tech.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./Arts-Tech/">
 <link rel="canonical" href="./Arts-Tech/">
 <script>location.replace("./Arts-Tech/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/tag/Arts-Tech/index.html
+++ b/docs/dexnotes/tag/Arts-Tech/index.html
@@ -466,7 +466,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-643287996266bb6c8e688f2b"

--- a/docs/dexnotes/tag/Baltimore.html
+++ b/docs/dexnotes/tag/Baltimore.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./Baltimore/">
 <link rel="canonical" href="./Baltimore/">
 <script>location.replace("./Baltimore/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/tag/Baltimore/index.html
+++ b/docs/dexnotes/tag/Baltimore/index.html
@@ -466,7 +466,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-643287996266bb6c8e688f2b"

--- a/docs/dexnotes/tag/Ben+Giroux.html
+++ b/docs/dexnotes/tag/Ben+Giroux.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./Ben+Giroux/">
 <link rel="canonical" href="./Ben+Giroux/">
 <script>location.replace("./Ben+Giroux/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/tag/Ben+Giroux/index.html
+++ b/docs/dexnotes/tag/Ben+Giroux/index.html
@@ -466,7 +466,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-643287996266bb6c8e688f2b"

--- a/docs/dexnotes/tag/Board+Search.html
+++ b/docs/dexnotes/tag/Board+Search.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./Board+Search/">
 <link rel="canonical" href="./Board+Search/">
 <script>location.replace("./Board+Search/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/tag/Board+Search/index.html
+++ b/docs/dexnotes/tag/Board+Search/index.html
@@ -466,7 +466,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-643287996266bb6c8e688f2b"

--- a/docs/dexnotes/tag/Cameron+Church.html
+++ b/docs/dexnotes/tag/Cameron+Church.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./Cameron+Church/">
 <link rel="canonical" href="./Cameron+Church/">
 <script>location.replace("./Cameron+Church/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/tag/Cameron+Church/index.html
+++ b/docs/dexnotes/tag/Cameron+Church/index.html
@@ -466,7 +466,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-643287996266bb6c8e688f2b"

--- a/docs/dexnotes/tag/Clara+Kelly.html
+++ b/docs/dexnotes/tag/Clara+Kelly.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./Clara+Kelly/">
 <link rel="canonical" href="./Clara+Kelly/">
 <script>location.replace("./Clara+Kelly/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/tag/Clara+Kelly/index.html
+++ b/docs/dexnotes/tag/Clara+Kelly/index.html
@@ -466,7 +466,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-643287996266bb6c8e688f2b"

--- a/docs/dexnotes/tag/Creative+Commons.html
+++ b/docs/dexnotes/tag/Creative+Commons.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./Creative+Commons/">
 <link rel="canonical" href="./Creative+Commons/">
 <script>location.replace("./Creative+Commons/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/tag/Creative+Commons/index.html
+++ b/docs/dexnotes/tag/Creative+Commons/index.html
@@ -466,7 +466,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-643287996266bb6c8e688f2b"

--- a/docs/dexnotes/tag/Directors.html
+++ b/docs/dexnotes/tag/Directors.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./Directors/">
 <link rel="canonical" href="./Directors/">
 <script>location.replace("./Directors/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/tag/Directors/index.html
+++ b/docs/dexnotes/tag/Directors/index.html
@@ -466,7 +466,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-643287996266bb6c8e688f2b"

--- a/docs/dexnotes/tag/Drop.html
+++ b/docs/dexnotes/tag/Drop.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./Drop/">
 <link rel="canonical" href="./Drop/">
 <script>location.replace("./Drop/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/tag/Drop/index.html
+++ b/docs/dexnotes/tag/Drop/index.html
@@ -466,7 +466,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-643287996266bb6c8e688f2b"

--- a/docs/dexnotes/tag/Governance.html
+++ b/docs/dexnotes/tag/Governance.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./Governance/">
 <link rel="canonical" href="./Governance/">
 <script>location.replace("./Governance/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/tag/Governance/index.html
+++ b/docs/dexnotes/tag/Governance/index.html
@@ -466,7 +466,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-643287996266bb6c8e688f2b"

--- a/docs/dexnotes/tag/LA+Artcore.html
+++ b/docs/dexnotes/tag/LA+Artcore.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./LA+Artcore/">
 <link rel="canonical" href="./LA+Artcore/">
 <script>location.replace("./LA+Artcore/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/tag/LA+Artcore/index.html
+++ b/docs/dexnotes/tag/LA+Artcore/index.html
@@ -466,7 +466,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-643287996266bb6c8e688f2b"

--- a/docs/dexnotes/tag/LA.html
+++ b/docs/dexnotes/tag/LA.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./LA/">
 <link rel="canonical" href="./LA/">
 <script>location.replace("./LA/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/tag/LA/index.html
+++ b/docs/dexnotes/tag/LA/index.html
@@ -466,7 +466,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-643287996266bb6c8e688f2b"

--- a/docs/dexnotes/tag/Launch.html
+++ b/docs/dexnotes/tag/Launch.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./Launch/">
 <link rel="canonical" href="./Launch/">
 <script>location.replace("./Launch/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/tag/Launch/index.html
+++ b/docs/dexnotes/tag/Launch/index.html
@@ -466,7 +466,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-643287996266bb6c8e688f2b"

--- a/docs/dexnotes/tag/Los+Angeles.html
+++ b/docs/dexnotes/tag/Los+Angeles.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./Los+Angeles/">
 <link rel="canonical" href="./Los+Angeles/">
 <script>location.replace("./Los+Angeles/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/tag/Los+Angeles/index.html
+++ b/docs/dexnotes/tag/Los+Angeles/index.html
@@ -466,7 +466,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-643287996266bb6c8e688f2b"

--- a/docs/dexnotes/tag/Max+Coleman.html
+++ b/docs/dexnotes/tag/Max+Coleman.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./Max+Coleman/">
 <link rel="canonical" href="./Max+Coleman/">
 <script>location.replace("./Max+Coleman/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/tag/Max+Coleman/index.html
+++ b/docs/dexnotes/tag/Max+Coleman/index.html
@@ -466,7 +466,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-643287996266bb6c8e688f2b"

--- a/docs/dexnotes/tag/Open+Access.html
+++ b/docs/dexnotes/tag/Open+Access.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./Open+Access/">
 <link rel="canonical" href="./Open+Access/">
 <script>location.replace("./Open+Access/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/tag/Open+Access/index.html
+++ b/docs/dexnotes/tag/Open+Access/index.html
@@ -466,7 +466,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-643287996266bb6c8e688f2b"

--- a/docs/dexnotes/tag/Programs.html
+++ b/docs/dexnotes/tag/Programs.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./Programs/">
 <link rel="canonical" href="./Programs/">
 <script>location.replace("./Programs/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/tag/Programs/index.html
+++ b/docs/dexnotes/tag/Programs/index.html
@@ -466,7 +466,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-643287996266bb6c8e688f2b"

--- a/docs/dexnotes/tag/Season+2.html
+++ b/docs/dexnotes/tag/Season+2.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./Season+2/">
 <link rel="canonical" href="./Season+2/">
 <script>location.replace("./Season+2/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/tag/Season+2/index.html
+++ b/docs/dexnotes/tag/Season+2/index.html
@@ -466,7 +466,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-643287996266bb6c8e688f2b"

--- a/docs/dexnotes/tag/Sky+Macklay.html
+++ b/docs/dexnotes/tag/Sky+Macklay.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./Sky+Macklay/">
 <link rel="canonical" href="./Sky+Macklay/">
 <script>location.replace("./Sky+Macklay/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/tag/Sky+Macklay/index.html
+++ b/docs/dexnotes/tag/Sky+Macklay/index.html
@@ -466,7 +466,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-643287996266bb6c8e688f2b"

--- a/docs/dexnotes/tag/Update.html
+++ b/docs/dexnotes/tag/Update.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./Update/">
 <link rel="canonical" href="./Update/">
 <script>location.replace("./Update/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/tag/Update/index.html
+++ b/docs/dexnotes/tag/Update/index.html
@@ -466,7 +466,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-643287996266bb6c8e688f2b"

--- a/docs/dexnotes/tag/artist+page.html
+++ b/docs/dexnotes/tag/artist+page.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./artist+page/">
 <link rel="canonical" href="./artist+page/">
 <script>location.replace("./artist+page/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/tag/artist+page/index.html
+++ b/docs/dexnotes/tag/artist+page/index.html
@@ -466,7 +466,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-643287996266bb6c8e688f2b"

--- a/docs/dexnotes/tag/dexFest.html
+++ b/docs/dexnotes/tag/dexFest.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./dexFest/">
 <link rel="canonical" href="./dexFest/">
 <script>location.replace("./dexFest/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/tag/dexFest/index.html
+++ b/docs/dexnotes/tag/dexFest/index.html
@@ -466,7 +466,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-643287996266bb6c8e688f2b"

--- a/docs/dexnotes/tag/electric+guitar.html
+++ b/docs/dexnotes/tag/electric+guitar.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./electric+guitar/">
 <link rel="canonical" href="./electric+guitar/">
 <script>location.replace("./electric+guitar/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/tag/electric+guitar/index.html
+++ b/docs/dexnotes/tag/electric+guitar/index.html
@@ -466,7 +466,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-643287996266bb6c8e688f2b"

--- a/docs/dexnotes/tag/electronics.html
+++ b/docs/dexnotes/tag/electronics.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./electronics/">
 <link rel="canonical" href="./electronics/">
 <script>location.replace("./electronics/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/tag/electronics/index.html
+++ b/docs/dexnotes/tag/electronics/index.html
@@ -466,7 +466,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-643287996266bb6c8e688f2b"

--- a/docs/dexnotes/tag/events.html
+++ b/docs/dexnotes/tag/events.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./events/">
 <link rel="canonical" href="./events/">
 <script>location.replace("./events/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/tag/events/index.html
+++ b/docs/dexnotes/tag/events/index.html
@@ -466,7 +466,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-643287996266bb6c8e688f2b"

--- a/docs/dexnotes/tag/festival.html
+++ b/docs/dexnotes/tag/festival.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./festival/">
 <link rel="canonical" href="./festival/">
 <script>location.replace("./festival/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/tag/festival/index.html
+++ b/docs/dexnotes/tag/festival/index.html
@@ -466,7 +466,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-643287996266bb6c8e688f2b"

--- a/docs/dexnotes/tag/griswold.html
+++ b/docs/dexnotes/tag/griswold.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./griswold/">
 <link rel="canonical" href="./griswold/">
 <script>location.replace("./griswold/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/tag/griswold/index.html
+++ b/docs/dexnotes/tag/griswold/index.html
@@ -466,7 +466,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-643287996266bb6c8e688f2b"

--- a/docs/dexnotes/tag/keyboard.html
+++ b/docs/dexnotes/tag/keyboard.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./keyboard/">
 <link rel="canonical" href="./keyboard/">
 <script>location.replace("./keyboard/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/tag/keyboard/index.html
+++ b/docs/dexnotes/tag/keyboard/index.html
@@ -466,7 +466,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-643287996266bb6c8e688f2b"

--- a/docs/dexnotes/tag/midori+ataka.html
+++ b/docs/dexnotes/tag/midori+ataka.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./midori+ataka/">
 <link rel="canonical" href="./midori+ataka/">
 <script>location.replace("./midori+ataka/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/tag/midori+ataka/index.html
+++ b/docs/dexnotes/tag/midori+ataka/index.html
@@ -466,7 +466,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-643287996266bb6c8e688f2b"

--- a/docs/dexnotes/tag/organ.html
+++ b/docs/dexnotes/tag/organ.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./organ/">
 <link rel="canonical" href="./organ/">
 <script>location.replace("./organ/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/tag/organ/index.html
+++ b/docs/dexnotes/tag/organ/index.html
@@ -466,7 +466,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-643287996266bb6c8e688f2b"

--- a/docs/dexnotes/tag/pedals.html
+++ b/docs/dexnotes/tag/pedals.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./pedals/">
 <link rel="canonical" href="./pedals/">
 <script>location.replace("./pedals/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/tag/pedals/index.html
+++ b/docs/dexnotes/tag/pedals/index.html
@@ -466,7 +466,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-643287996266bb6c8e688f2b"

--- a/docs/dexnotes/tag/percussion.html
+++ b/docs/dexnotes/tag/percussion.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./percussion/">
 <link rel="canonical" href="./percussion/">
 <script>location.replace("./percussion/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/tag/percussion/index.html
+++ b/docs/dexnotes/tag/percussion/index.html
@@ -466,7 +466,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-643287996266bb6c8e688f2b"

--- a/docs/dexnotes/tag/portative+organ.html
+++ b/docs/dexnotes/tag/portative+organ.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./portative+organ/">
 <link rel="canonical" href="./portative+organ/">
 <script>location.replace("./portative+organ/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/tag/portative+organ/index.html
+++ b/docs/dexnotes/tag/portative+organ/index.html
@@ -466,7 +466,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-643287996266bb6c8e688f2b"

--- a/docs/dexnotes/tag/prepared+hammered+dulcimer.html
+++ b/docs/dexnotes/tag/prepared+hammered+dulcimer.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./prepared+hammered+dulcimer/">
 <link rel="canonical" href="./prepared+hammered+dulcimer/">
 <script>location.replace("./prepared+hammered+dulcimer/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/tag/prepared+hammered+dulcimer/index.html
+++ b/docs/dexnotes/tag/prepared+hammered+dulcimer/index.html
@@ -466,7 +466,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-643287996266bb6c8e688f2b"

--- a/docs/dexnotes/tag/prepared+harpsichord.html
+++ b/docs/dexnotes/tag/prepared+harpsichord.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./prepared+harpsichord/">
 <link rel="canonical" href="./prepared+harpsichord/">
 <script>location.replace("./prepared+harpsichord/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/tag/prepared+harpsichord/index.html
+++ b/docs/dexnotes/tag/prepared+harpsichord/index.html
@@ -466,7 +466,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-643287996266bb6c8e688f2b"

--- a/docs/dexnotes/tag/prepared+piano.html
+++ b/docs/dexnotes/tag/prepared+piano.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./prepared+piano/">
 <link rel="canonical" href="./prepared+piano/">
 <script>location.replace("./prepared+piano/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/tag/prepared+piano/index.html
+++ b/docs/dexnotes/tag/prepared+piano/index.html
@@ -466,7 +466,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-643287996266bb6c8e688f2b"

--- a/docs/dexnotes/tag/prepared+viol.html
+++ b/docs/dexnotes/tag/prepared+viol.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./prepared+viol/">
 <link rel="canonical" href="./prepared+viol/">
 <script>location.replace("./prepared+viol/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/tag/prepared+viol/index.html
+++ b/docs/dexnotes/tag/prepared+viol/index.html
@@ -466,7 +466,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-643287996266bb6c8e688f2b"

--- a/docs/dexnotes/tag/season+1.html
+++ b/docs/dexnotes/tag/season+1.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./season+1/">
 <link rel="canonical" href="./season+1/">
 <script>location.replace("./season+1/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/tag/season+1/index.html
+++ b/docs/dexnotes/tag/season+1/index.html
@@ -466,7 +466,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-643287996266bb6c8e688f2b"

--- a/docs/dexnotes/tag/strings.html
+++ b/docs/dexnotes/tag/strings.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./strings/">
 <link rel="canonical" href="./strings/">
 <script>location.replace("./strings/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/tag/strings/index.html
+++ b/docs/dexnotes/tag/strings/index.html
@@ -466,7 +466,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-643287996266bb6c8e688f2b"

--- a/docs/dexnotes/tag/viola+da+gamba.html
+++ b/docs/dexnotes/tag/viola+da+gamba.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./viola+da+gamba/">
 <link rel="canonical" href="./viola+da+gamba/">
 <script>location.replace("./viola+da+gamba/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/tag/viola+da+gamba/index.html
+++ b/docs/dexnotes/tag/viola+da+gamba/index.html
@@ -466,7 +466,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-643287996266bb6c8e688f2b"

--- a/docs/dexnotes/tag/zarb.html
+++ b/docs/dexnotes/tag/zarb.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./zarb/">
 <link rel="canonical" href="./zarb/">
 <script>location.replace("./zarb/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes/tag/zarb/index.html
+++ b/docs/dexnotes/tag/zarb/index.html
@@ -466,7 +466,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-643287996266bb6c8e688f2b"

--- a/docs/dexnotes?author=5f5a38b445de701d4778d80c.html
+++ b/docs/dexnotes?author=5f5a38b445de701d4778d80c.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./dexnotes?author=5f5a38b445de701d4778d80c/">
 <link rel="canonical" href="./dexnotes?author=5f5a38b445de701d4778d80c/">
 <script>location.replace("./dexnotes?author=5f5a38b445de701d4778d80c/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes?author=5f5a38b445de701d4778d80c/index.html
+++ b/docs/dexnotes?author=5f5a38b445de701d4778d80c/index.html
@@ -466,7 +466,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-643287996266bb6c8e688f2b"

--- a/docs/dexnotes?author=68acf7dce29f8247986d0e3f.html
+++ b/docs/dexnotes?author=68acf7dce29f8247986d0e3f.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./dexnotes?author=68acf7dce29f8247986d0e3f/">
 <link rel="canonical" href="./dexnotes?author=68acf7dce29f8247986d0e3f/">
 <script>location.replace("./dexnotes?author=68acf7dce29f8247986d0e3f/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/dexnotes?author=68acf7dce29f8247986d0e3f/index.html
+++ b/docs/dexnotes?author=68acf7dce29f8247986d0e3f/index.html
@@ -466,7 +466,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script src=https://zeffy-scripts.s3.ca-central-1.amazonaws.com/embed-form-script.min.js></script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-643287996266bb6c8e688f2b"

--- a/docs/donate.html
+++ b/docs/donate.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./donate/">
 <link rel="canonical" href="./donate/">
 <script>location.replace("./donate/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/donate/index.html
+++ b/docs/donate/index.html
@@ -465,7 +465,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-6744c4894c3c4f49cdd05b95"

--- a/docs/hero.html
+++ b/docs/hero.html
@@ -34,3 +34,7 @@
     });
   </script>
 </section>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -497,7 +497,11 @@ body {
   </style><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-6887d73d8489aa17805a5bbc"

--- a/docs/messages.html
+++ b/docs/messages.html
@@ -473,7 +473,11 @@ html, body {
 <script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-688ff6cba37c6a6a4900935c"

--- a/docs/polls.html
+++ b/docs/polls.html
@@ -472,7 +472,11 @@ html, body {
 </style><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-688ddc09b72a2627025d46e7"

--- a/docs/pressroom.html
+++ b/docs/pressroom.html
@@ -473,7 +473,11 @@ html, body {
 <script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-68907cd9502c7027ef5aa9ac"

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./privacy/">
 <link rel="canonical" href="./privacy/">
 <script>location.replace("./privacy/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/privacy/index.html
+++ b/docs/privacy/index.html
@@ -465,7 +465,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-6433a64bc04fcf75818c2605"

--- a/docs/programs.html
+++ b/docs/programs.html
@@ -3,3 +3,7 @@
 <meta http-equiv="refresh" content="0; url=./programs/">
 <link rel="canonical" href="./programs/">
 <script>location.replace("./programs/");</script>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/docs/programs/index.html
+++ b/docs/programs/index.html
@@ -465,7 +465,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </script><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-68b0a3ecfdfd507abd81c56f"

--- a/docs/submit.html
+++ b/docs/submit.html
@@ -472,7 +472,11 @@ html, body {
 </style><script>Static.COOKIE_BANNER_CAPABLE = true;</script>
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-J5DDMNH264"></script><script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('set', 'developer_id.dZjQwMz', true);gtag('consent', 'default', { 'analytics_storage': 'denied', 'wait_for_update': 500 });window.googleAnalyticsRequiresConsentUpdates = true;(function(){let squarespaceCookies = {};if (window.getSquarespaceCookies) {  squarespaceCookies = window.getSquarespaceCookies();}const consentValue = squarespaceCookies.performance === 'accepted' ? 'granted' :  'denied';gtag('consent', 'update', { 'analytics_storage': consentValue })})();gtag('config', 'G-J5DDMNH264');</script><!-- End of Squarespace Headers -->
     <link rel="stylesheet" type="text/css" href="https://static1.squarespace.com/static/vta/5c5a519771c10ba3470d8101/versioned-assets/1771441478242-2KJ6E4XSE8IDDFKSAHZS/static.css">
-  </head>
+  
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>
+</head>
 
   <body
     id="collection-688ee82c5857e07284f0b046"

--- a/entry/2-organs-midori-ataka/index.html
+++ b/entry/2-organs-midori-ataka/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Dex — Protected (Dev Stub)</title>
+  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+  <script defer src="/assets/dex-auth0-config.js"></script>
+  <script defer src="/assets/dex-auth.js"></script>
+  <style>
+    body { margin: 2rem; font-family: Arial, sans-serif; }
+  </style>
+</head>
+<body>
+  <h1>Dex — Protected (Dev Stub)</h1>
+  <p>This protected route is a development placeholder.</p>
+</body>
+</html>

--- a/entry/aidan-yeats/index.html
+++ b/entry/aidan-yeats/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Dex — Protected (Dev Stub)</title>
+  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+  <script defer src="/assets/dex-auth0-config.js"></script>
+  <script defer src="/assets/dex-auth.js"></script>
+  <style>
+    body { margin: 2rem; font-family: Arial, sans-serif; }
+  </style>
+</head>
+<body>
+  <h1>Dex — Protected (Dev Stub)</h1>
+  <p>This protected route is a development placeholder.</p>
+</body>
+</html>

--- a/entry/amplified-knives-tyler-jordan/index.html
+++ b/entry/amplified-knives-tyler-jordan/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Dex — Protected (Dev Stub)</title>
+  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+  <script defer src="/assets/dex-auth0-config.js"></script>
+  <script defer src="/assets/dex-auth.js"></script>
+  <style>
+    body { margin: 2rem; font-family: Arial, sans-serif; }
+  </style>
+</head>
+<body>
+  <h1>Dex — Protected (Dev Stub)</h1>
+  <p>This protected route is a development placeholder.</p>
+</body>
+</html>

--- a/entry/amplified-printer/index.html
+++ b/entry/amplified-printer/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Dex — Protected (Dev Stub)</title>
+  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+  <script defer src="/assets/dex-auth0-config.js"></script>
+  <script defer src="/assets/dex-auth.js"></script>
+  <style>
+    body { margin: 2rem; font-family: Arial, sans-serif; }
+  </style>
+</head>
+<body>
+  <h1>Dex — Protected (Dev Stub)</h1>
+  <p>This protected route is a development placeholder.</p>
+</body>
+</html>

--- a/entry/amplified-tv-sam-pluta/index.html
+++ b/entry/amplified-tv-sam-pluta/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Dex — Protected (Dev Stub)</title>
+  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+  <script defer src="/assets/dex-auth0-config.js"></script>
+  <script defer src="/assets/dex-auth.js"></script>
+  <style>
+    body { margin: 2rem; font-family: Arial, sans-serif; }
+  </style>
+</head>
+<body>
+  <h1>Dex — Protected (Dev Stub)</h1>
+  <p>This protected route is a development placeholder.</p>
+</body>
+</html>

--- a/entry/anant-shah/index.html
+++ b/entry/anant-shah/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Dex — Protected (Dev Stub)</title>
+  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+  <script defer src="/assets/dex-auth0-config.js"></script>
+  <script defer src="/assets/dex-auth.js"></script>
+  <style>
+    body { margin: 2rem; font-family: Arial, sans-serif; }
+  </style>
+</head>
+<body>
+  <h1>Dex — Protected (Dev Stub)</h1>
+  <p>This protected route is a development placeholder.</p>
+</body>
+</html>

--- a/entry/andrew-chanover/index.html
+++ b/entry/andrew-chanover/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Dex — Protected (Dev Stub)</title>
+  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+  <script defer src="/assets/dex-auth0-config.js"></script>
+  <script defer src="/assets/dex-auth.js"></script>
+  <style>
+    body { margin: 2rem; font-family: Arial, sans-serif; }
+  </style>
+</head>
+<body>
+  <h1>Dex — Protected (Dev Stub)</h1>
+  <p>This protected route is a development placeholder.</p>
+</body>
+</html>

--- a/entry/as-though-im-slipping/index.html
+++ b/entry/as-though-im-slipping/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Dex — Protected (Dev Stub)</title>
+  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+  <script defer src="/assets/dex-auth0-config.js"></script>
+  <script defer src="/assets/dex-auth.js"></script>
+  <style>
+    body { margin: 2rem; font-family: Arial, sans-serif; }
+  </style>
+</head>
+<body>
+  <h1>Dex — Protected (Dev Stub)</h1>
+  <p>This protected route is a development placeholder.</p>
+</body>
+</html>

--- a/entry/bassoon-and-electronics/index.html
+++ b/entry/bassoon-and-electronics/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Dex — Protected (Dev Stub)</title>
+  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+  <script defer src="/assets/dex-auth0-config.js"></script>
+  <script defer src="/assets/dex-auth.js"></script>
+  <style>
+    body { margin: 2rem; font-family: Arial, sans-serif; }
+  </style>
+</head>
+<body>
+  <h1>Dex — Protected (Dev Stub)</h1>
+  <p>This protected route is a development placeholder.</p>
+</body>
+</html>

--- a/entry/bojun-zhang/index.html
+++ b/entry/bojun-zhang/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Dex — Protected (Dev Stub)</title>
+  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+  <script defer src="/assets/dex-auth0-config.js"></script>
+  <script defer src="/assets/dex-auth.js"></script>
+  <style>
+    body { margin: 2rem; font-family: Arial, sans-serif; }
+  </style>
+</head>
+<body>
+  <h1>Dex — Protected (Dev Stub)</h1>
+  <p>This protected route is a development placeholder.</p>
+</body>
+</html>

--- a/entry/cello-emmanuel-losa/index.html
+++ b/entry/cello-emmanuel-losa/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Dex — Protected (Dev Stub)</title>
+  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+  <script defer src="/assets/dex-auth0-config.js"></script>
+  <script defer src="/assets/dex-auth.js"></script>
+  <style>
+    body { margin: 2rem; font-family: Arial, sans-serif; }
+  </style>
+</head>
+<body>
+  <h1>Dex — Protected (Dev Stub)</h1>
+  <p>This protected route is a development placeholder.</p>
+</body>
+</html>

--- a/entry/cybernetic-scat-paul-hermansen/index.html
+++ b/entry/cybernetic-scat-paul-hermansen/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Dex — Protected (Dev Stub)</title>
+  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+  <script defer src="/assets/dex-auth0-config.js"></script>
+  <script defer src="/assets/dex-auth.js"></script>
+  <style>
+    body { margin: 2rem; font-family: Arial, sans-serif; }
+  </style>
+</head>
+<body>
+  <h1>Dex — Protected (Dev Stub)</h1>
+  <p>This protected route is a development placeholder.</p>
+</body>
+</html>

--- a/entry/electric-guitar-chris-mann/index.html
+++ b/entry/electric-guitar-chris-mann/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Dex — Protected (Dev Stub)</title>
+  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+  <script defer src="/assets/dex-auth0-config.js"></script>
+  <script defer src="/assets/dex-auth.js"></script>
+  <style>
+    body { margin: 2rem; font-family: Arial, sans-serif; }
+  </style>
+</head>
+<body>
+  <h1>Dex — Protected (Dev Stub)</h1>
+  <p>This protected route is a development placeholder.</p>
+</body>
+</html>

--- a/entry/electric-guitar-pedals-ethan-bailey-gould/index.html
+++ b/entry/electric-guitar-pedals-ethan-bailey-gould/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Dex — Protected (Dev Stub)</title>
+  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+  <script defer src="/assets/dex-auth0-config.js"></script>
+  <script defer src="/assets/dex-auth.js"></script>
+  <style>
+    body { margin: 2rem; font-family: Arial, sans-serif; }
+  </style>
+</head>
+<body>
+  <h1>Dex — Protected (Dev Stub)</h1>
+  <p>This protected route is a development placeholder.</p>
+</body>
+</html>

--- a/entry/hammered-dulcimer-cameron-church/index.html
+++ b/entry/hammered-dulcimer-cameron-church/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Dex — Protected (Dev Stub)</title>
+  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+  <script defer src="/assets/dex-auth0-config.js"></script>
+  <script defer src="/assets/dex-auth.js"></script>
+  <style>
+    body { margin: 2rem; font-family: Arial, sans-serif; }
+  </style>
+</head>
+<body>
+  <h1>Dex — Protected (Dev Stub)</h1>
+  <p>This protected route is a development placeholder.</p>
+</body>
+</html>

--- a/entry/multiperc/index.html
+++ b/entry/multiperc/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Dex — Protected (Dev Stub)</title>
+  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+  <script defer src="/assets/dex-auth0-config.js"></script>
+  <script defer src="/assets/dex-auth.js"></script>
+  <style>
+    body { margin: 2rem; font-family: Arial, sans-serif; }
+  </style>
+</head>
+<body>
+  <h1>Dex — Protected (Dev Stub)</h1>
+  <p>This protected route is a development placeholder.</p>
+</body>
+</html>

--- a/entry/no-input-mixer-jared-murphy/index.html
+++ b/entry/no-input-mixer-jared-murphy/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Dex — Protected (Dev Stub)</title>
+  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+  <script defer src="/assets/dex-auth0-config.js"></script>
+  <script defer src="/assets/dex-auth.js"></script>
+  <style>
+    body { margin: 2rem; font-family: Arial, sans-serif; }
+  </style>
+</head>
+<body>
+  <h1>Dex — Protected (Dev Stub)</h1>
+  <p>This protected route is a development placeholder.</p>
+</body>
+</html>

--- a/entry/prepared-bass-viol-suarez-solis/index.html
+++ b/entry/prepared-bass-viol-suarez-solis/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Dex — Protected (Dev Stub)</title>
+  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+  <script defer src="/assets/dex-auth0-config.js"></script>
+  <script defer src="/assets/dex-auth.js"></script>
+  <style>
+    body { margin: 2rem; font-family: Arial, sans-serif; }
+  </style>
+</head>
+<body>
+  <h1>Dex — Protected (Dev Stub)</h1>
+  <p>This protected route is a development placeholder.</p>
+</body>
+</html>

--- a/entry/prepared-harpsichord-suarez-solis/index.html
+++ b/entry/prepared-harpsichord-suarez-solis/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Dex — Protected (Dev Stub)</title>
+  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+  <script defer src="/assets/dex-auth0-config.js"></script>
+  <script defer src="/assets/dex-auth.js"></script>
+  <style>
+    body { margin: 2rem; font-family: Arial, sans-serif; }
+  </style>
+</head>
+<body>
+  <h1>Dex — Protected (Dev Stub)</h1>
+  <p>This protected route is a development placeholder.</p>
+</body>
+</html>

--- a/entry/prepared-oboe-sky-macklay/index.html
+++ b/entry/prepared-oboe-sky-macklay/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Dex — Protected (Dev Stub)</title>
+  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+  <script defer src="/assets/dex-auth0-config.js"></script>
+  <script defer src="/assets/dex-auth.js"></script>
+  <style>
+    body { margin: 2rem; font-family: Arial, sans-serif; }
+  </style>
+</head>
+<body>
+  <h1>Dex — Protected (Dev Stub)</h1>
+  <p>This protected route is a development placeholder.</p>
+</body>
+</html>

--- a/entry/sebastian-suarez-solis/index.html
+++ b/entry/sebastian-suarez-solis/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Dex — Protected (Dev Stub)</title>
+  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+  <script defer src="/assets/dex-auth0-config.js"></script>
+  <script defer src="/assets/dex-auth.js"></script>
+  <style>
+    body { margin: 2rem; font-family: Arial, sans-serif; }
+  </style>
+</head>
+<body>
+  <h1>Dex — Protected (Dev Stub)</h1>
+  <p>This protected route is a development placeholder.</p>
+</body>
+</html>

--- a/entry/splinterings-jakob-heinemann/index.html
+++ b/entry/splinterings-jakob-heinemann/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Dex — Protected (Dev Stub)</title>
+  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+  <script defer src="/assets/dex-auth0-config.js"></script>
+  <script defer src="/assets/dex-auth.js"></script>
+  <style>
+    body { margin: 2rem; font-family: Arial, sans-serif; }
+  </style>
+</head>
+<body>
+  <h1>Dex — Protected (Dev Stub)</h1>
+  <p>This protected route is a development placeholder.</p>
+</body>
+</html>

--- a/entry/this-is-a-tangible-space/index.html
+++ b/entry/this-is-a-tangible-space/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Dex — Protected (Dev Stub)</title>
+  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+  <script defer src="/assets/dex-auth0-config.js"></script>
+  <script defer src="/assets/dex-auth.js"></script>
+  <style>
+    body { margin: 2rem; font-family: Arial, sans-serif; }
+  </style>
+</head>
+<body>
+  <h1>Dex — Protected (Dev Stub)</h1>
+  <p>This protected route is a development placeholder.</p>
+</body>
+</html>

--- a/entry/tim-feeney/index.html
+++ b/entry/tim-feeney/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Dex — Protected (Dev Stub)</title>
+  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+  <script defer src="/assets/dex-auth0-config.js"></script>
+  <script defer src="/assets/dex-auth.js"></script>
+  <style>
+    body { margin: 2rem; font-family: Arial, sans-serif; }
+  </style>
+</head>
+<body>
+  <h1>Dex — Protected (Dev Stub)</h1>
+  <p>This protected route is a development placeholder.</p>
+</body>
+</html>

--- a/entry/voice-everyday-object-manipulation-levi-lu/index.html
+++ b/entry/voice-everyday-object-manipulation-levi-lu/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Dex — Protected (Dev Stub)</title>
+  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+  <script defer src="/assets/dex-auth0-config.js"></script>
+  <script defer src="/assets/dex-auth.js"></script>
+  <style>
+    body { margin: 2rem; font-family: Arial, sans-serif; }
+  </style>
+</head>
+<body>
+  <h1>Dex — Protected (Dev Stub)</h1>
+  <p>This protected route is a development placeholder.</p>
+</body>
+</html>

--- a/hero.html
+++ b/hero.html
@@ -34,3 +34,7 @@
     });
   </script>
 </section>
+
+<script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+<script defer src="/assets/dex-auth0-config.js"></script>
+<script defer src="/assets/dex-auth.js"></script>

--- a/press/index.html
+++ b/press/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Dex — Protected (Dev Stub)</title>
+  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
+  <script defer src="/assets/dex-auth0-config.js"></script>
+  <script defer src="/assets/dex-auth.js"></script>
+  <style>
+    body { margin: 2rem; font-family: Arial, sans-serif; }
+  </style>
+</head>
+<body>
+  <h1>Dex — Protected (Dev Stub)</h1>
+  <p>This protected route is a development placeholder.</p>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide client-side Auth0 SPA login, header auth UI, and UX route-guards for a set of exact protected routes while keeping changes additive and preserving the existing static snapshot.
- Ensure same-origin click-time interception and direct-navigation protection so unauthenticated users are redirected straight to Auth0 Universal Login and return to the original route after sign-in.
- Ship minimal dev-friendly serverless stubs (folder-based GitHub Pages style) so protected routes do not 404 while the real content is developed.

### Description
- Added host-mapped config `assets/dex-auth0-config.js` that exposes `window.DEX_AUTH0_CONFIG` with entries for `dexdsl.github.io`, `dexdsl.org`, and `dexdsl.com` and a callback URI at `/auth/callback/`; unknown hosts set config to `null` and log a `[dex-auth]` warning.
- Implemented `assets/dex-auth.js` (vanilla IIFE) that: performs exact protected-path matching for `/press` and the specified `/entry/<slug>` list (handles trailing slash normalization), injects an idempotent SIGN IN / avatar dropdown UI (mounts into `.header-actions--right` / `.header-actions` / `header` / `body`), hides legacy account UI selectors, initialises the Auth0 SPA client when available, handles `/auth/callback/` redirects, intercepts same-origin clicked `<a>` targets in the capture phase for protected routes to call `loginWithRedirect({ appState: { returnTo } })`, and guards direct navigation by redirecting unauthenticated users immediately.
- Added `auth/callback/index.html` to complete redirect callback handling by loading the Auth0 SDK + local config and auth script and showing a minimal "Signing you in…" page.
- Created protected-route stubs (folder + `index.html`) for `/press/` and each exact `/entry/<slug>/` in the provided list; each stub loads the three defer scripts so the auth UI appears on the stub and the route-guard behavior is active.
- Injected the three `<script defer>` tags (Auth0 SPA SDK + `/assets/dex-auth0-config.js` + `/assets/dex-auth.js`) into all existing HTML snapshot files where possible (inserted before `</head>` or before `</body>` when `</head>` not present), avoiding duplicate tags and preserving all existing markup/paths and navigation behavior.
- Fail-safes: the auth code logs all errors with a `[dex-auth]` prefix and gracefully degrades if the Auth0 SDK or host config is missing so page interactivity is not broken.

### Testing
- Syntax/static checks: ran `node --check assets/dex-auth.js` and `node --check assets/dex-auth0-config.js`, and both returned OK.
- File/coverage validation: ran small Python checks that confirmed the callback page exists and all 25 protected `entry/<slug>/index.html` pages plus `press/index.html` were created, and a scan confirmed the three script tags are present in all non-`node_modules` HTML files (no duplicates found).
- Attempted browser rendering/screenshot with Playwright to capture the injected UI, but the Chromium process crashed in this environment (SIGSEGV), so no automated UI screenshot could be produced; this is an environment limitation and not a code failure.
- Manual testing checklist (to be run in a browser / incognito with a real Auth0 tenant configured):
  - Incognito: open `/` then click a protected link → should redirect immediately to Auth0 Universal Login (no intermediate page).
  - After login: Auth0 should return to the exact protected route via `appState.returnTo` and display the auth header UI (avatar + dropdown) while the page shows the stub content.
  - Avatar dropdown appears and `SIGN IN` is hidden when authenticated; logout returns to `window.location.origin` and `SIGN IN` reappears.
  - Direct navigation to a protected URL while logged out should redirect to Auth0 login and then return to that URL after login.
  - Visiting an unprotected URL should never trigger login.
  - Console should show no uncaught exceptions on pages missing header containers (the script is resilient and idempotent).

Files added or modified (high level): `assets/dex-auth0-config.js`, `assets/dex-auth.js`, `auth/callback/index.html`, `press/index.html`, `entry/<slug>/index.html` (25 slugs), and injected defer scripts into the static HTML snapshot files so auth logic runs across the site.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997d272696083279b095e88669589cc)