### PR TITLE
Fix Auth0 SPA v1 request shape and add protected-route stubs

### DIFF
--- a/assets/dex-auth.js
+++ b/assets/dex-auth.js
@@ -1,0 +1,406 @@
+(function () {
+  "use strict";
+
+  var AUTH_UI_ID = "auth-ui";
+  var DROPDOWN_OPEN_CLASS = "is-open";
+  var PROTECTED_PATHS = {
+    "/press": true,
+    "/polls": true,
+    "/entry/submit": true,
+    "/entry/messages": true,
+    "/entry/achievements": true,
+    "/entry/pressroom": true,
+    "/entry/2-organs-midori-ataka": true,
+    "/entry/aidan-yeats": true,
+    "/entry/amplified-knives-tyler-jordan": true,
+    "/entry/amplified-printer": true,
+    "/entry/amplified-tv-sam-pluta": true,
+    "/entry/anant-shah": true,
+    "/entry/andrew-chanover": true,
+    "/entry/as-though-im-slipping": true,
+    "/entry/bassoon-and-electronics": true,
+    "/entry/bojun-zhang": true,
+    "/entry/cello-emmanuel-losa": true,
+    "/entry/cybernetic-scat-paul-hermansen": true,
+    "/entry/electric-guitar-chris-mann": true,
+    "/entry/electric-guitar-pedals-ethan-bailey-gould": true,
+    "/entry/hammered-dulcimer-cameron-church": true,
+    "/entry/multiperc": true,
+    "/entry/no-input-mixer-jared-murphy": true,
+    "/entry/prepared-bass-viol-suarez-solis": true,
+    "/entry/prepared-harpsichord-suarez-solis": true,
+    "/entry/prepared-oboe-sky-macklay": true,
+    "/entry/sebastian-suarez-solis": true,
+    "/entry/splinterings-jakob-heinemann": true,
+    "/entry/this-is-a-tangible-space": true,
+    "/entry/tim-feeney": true,
+    "/entry/voice-everyday-object-manipulation-levi-lu": true
+  };
+
+  var LINK_NORMALIZE_MAP = {
+    "polls": "/polls/",
+    "polls/": "/polls/",
+    "entry/submit": "/entry/submit/",
+    "entry/submit/": "/entry/submit/",
+    "entry/messages": "/entry/messages/",
+    "entry/messages/": "/entry/messages/",
+    "entry/achievements": "/entry/achievements/",
+    "entry/achievements/": "/entry/achievements/",
+    "entry/pressroom": "/entry/pressroom/",
+    "entry/pressroom/": "/entry/pressroom/",
+    "press": "/press/",
+    "press/": "/press/"
+  };
+
+  var authClient = null;
+  var isAuthenticated = false;
+
+  function logError() {
+    var args = Array.prototype.slice.call(arguments);
+    args.unshift("[dex-auth]");
+    console.error.apply(console, args);
+  }
+
+  function normalizePath(pathname) {
+    var path = pathname || "/";
+    if (typeof path !== "string") {
+      path = String(path || "/");
+    }
+    if (!path) {
+      return "/";
+    }
+    if (path.charAt(0) !== "/") {
+      path = "/" + path;
+    }
+    path = path.replace(/\/+/g, "/");
+    if (path.length > 1 && path.charAt(path.length - 1) === "/") {
+      path = path.slice(0, -1);
+    }
+    return path || "/";
+  }
+
+  function isProtectedPath(pathname) {
+    return !!PROTECTED_PATHS[normalizePath(pathname)];
+  }
+
+  function isCallbackPath(pathname) {
+    return normalizePath(pathname).indexOf("/auth/callback") === 0;
+  }
+
+  function getReturnToFromUrl(urlObj) {
+    return (urlObj.pathname || "/") + (urlObj.search || "") + (urlObj.hash || "");
+  }
+
+  function normalizeKnownProtectedLinks() {
+    var anchors = document.querySelectorAll("a[href]");
+    for (var i = 0; i < anchors.length; i += 1) {
+      var raw = (anchors[i].getAttribute("href") || "").trim();
+      if (!raw || raw.charAt(0) === "/" || raw.indexOf("http") === 0 || raw.charAt(0) === "#") {
+        continue;
+      }
+      if (LINK_NORMALIZE_MAP[raw]) {
+        anchors[i].setAttribute("href", LINK_NORMALIZE_MAP[raw]);
+      }
+    }
+  }
+
+  function hideLegacyAccountUi() {
+    var nodes = document.querySelectorAll(
+      ".customerAccountLoginDesktop, .customerAccountLoginMobile, [data-controller='UserAccountLink']"
+    );
+    for (var i = 0; i < nodes.length; i += 1) {
+      nodes[i].style.display = "none";
+    }
+  }
+
+  function ensureAuthUi() {
+    if (document.getElementById(AUTH_UI_ID)) {
+      return document.getElementById(AUTH_UI_ID);
+    }
+
+    hideLegacyAccountUi();
+
+    var styleId = "dex-auth-style";
+    if (!document.getElementById(styleId)) {
+      var style = document.createElement("style");
+      style.id = styleId;
+      style.textContent = ""
+        + "#auth-ui{position:relative;display:inline-flex;align-items:center;gap:10px;font-family:inherit;}"
+        + "#auth-ui [hidden]{display:none!important;}"
+        + "#auth-ui-signin{padding:8px 12px;border:1px solid #111;background:#fff;color:#111;cursor:pointer;font-size:12px;letter-spacing:.08em;text-transform:uppercase;}"
+        + "#auth-ui-profile-toggle{display:inline-flex;align-items:center;justify-content:center;border:1px solid #d4d4d4;background:#fff;width:36px;height:36px;border-radius:9999px;cursor:pointer;padding:0;}"
+        + "#auth-ui-avatar{width:100%;height:100%;border-radius:9999px;object-fit:cover;display:block;}"
+        + "#auth-ui-dropdown{position:absolute;right:0;top:calc(100% + 8px);min-width:220px;border:1px solid #ddd;background:#fff;box-shadow:0 8px 24px rgba(0,0,0,.12);padding:8px;z-index:9999;display:none;}"
+        + "#auth-ui-dropdown." + DROPDOWN_OPEN_CLASS + "{display:block;}"
+        + "#auth-ui-dropdown a{display:block;padding:6px 8px;color:#111;text-decoration:none;font-size:13px;}"
+        + "#auth-ui-dropdown a:hover{background:#f2f2f2;}"
+        + "#auth-ui-logout{width:100%;border:1px solid #111;background:#fff;padding:8px 10px;cursor:pointer;font-size:12px;letter-spacing:.08em;text-transform:uppercase;margin-top:8px;}";
+      document.head.appendChild(style);
+    }
+
+    var ui = document.createElement("div");
+    ui.id = AUTH_UI_ID;
+    ui.innerHTML = ""
+      + '<button id="auth-ui-signin" type="button">SIGN IN</button>'
+      + '<div id="auth-ui-profile" hidden>'
+      + '  <button id="auth-ui-profile-toggle" type="button" aria-haspopup="true" aria-expanded="false" title="Profile">'
+      + '    <img id="auth-ui-avatar" alt="Profile avatar" src="data:image/gif;base64,R0lGODlhAQABAAAAACw=">'
+      + "  </button>"
+      + '  <div id="auth-ui-dropdown" role="menu">'
+      + '    <a href="/polls/" role="menuitem">Polls</a>'
+      + '    <a href="/entry/submit/" role="menuitem">Submit</a>'
+      + '    <a href="/entry/messages/" role="menuitem">Messages</a>'
+      + '    <a href="/entry/pressroom/" role="menuitem">Pressroom</a>'
+      + '    <a href="/entry/achievements/" role="menuitem">Achievements</a>'
+      + '    <a href="/press/" role="menuitem">Press</a>'
+      + '    <button id="auth-ui-logout" type="button">Log out</button>'
+      + "  </div>"
+      + "</div>";
+
+    var mount = document.querySelector(".header-actions--right") ||
+      document.querySelector(".header-actions") ||
+      document.querySelector("header") ||
+      document.body;
+    mount.appendChild(ui);
+    return ui;
+  }
+
+  function setUiState(auth, user) {
+    var ui = ensureAuthUi();
+    if (!ui) {
+      return;
+    }
+    var signInBtn = document.getElementById("auth-ui-signin");
+    var profileWrap = document.getElementById("auth-ui-profile");
+    var profileToggle = document.getElementById("auth-ui-profile-toggle");
+    var avatar = document.getElementById("auth-ui-avatar");
+
+    if (!signInBtn || !profileWrap || !profileToggle || !avatar) {
+      return;
+    }
+
+    if (auth) {
+      signInBtn.hidden = true;
+      profileWrap.hidden = false;
+      if (user && user.picture) {
+        avatar.src = user.picture;
+      }
+      if (user && user.name) {
+        profileToggle.title = user.name;
+      }
+    } else {
+      signInBtn.hidden = false;
+      profileWrap.hidden = true;
+    }
+  }
+
+  function closeDropdown() {
+    var menu = document.getElementById("auth-ui-dropdown");
+    var toggle = document.getElementById("auth-ui-profile-toggle");
+    if (menu) {
+      menu.classList.remove(DROPDOWN_OPEN_CLASS);
+    }
+    if (toggle) {
+      toggle.setAttribute("aria-expanded", "false");
+    }
+  }
+
+  function bindUiEvents(cfg) {
+    var signInBtn = document.getElementById("auth-ui-signin");
+    var profileWrap = document.getElementById("auth-ui-profile");
+    var profileToggle = document.getElementById("auth-ui-profile-toggle");
+    var logoutBtn = document.getElementById("auth-ui-logout");
+    var dropdown = document.getElementById("auth-ui-dropdown");
+
+    if (signInBtn && !signInBtn.dataset.bound) {
+      signInBtn.dataset.bound = "1";
+      signInBtn.addEventListener("click", function () {
+        if (!authClient) {
+          logError("Auth client unavailable for sign in.");
+          return;
+        }
+        authClient.loginWithRedirect({
+          appState: { returnTo: window.location.pathname + window.location.search + window.location.hash },
+          redirect_uri: cfg.redirectUri
+        }).catch(function (err) {
+          logError("loginWithRedirect failed:", err);
+        });
+      });
+    }
+
+    if (profileToggle && !profileToggle.dataset.bound) {
+      profileToggle.dataset.bound = "1";
+      profileToggle.addEventListener("click", function (evt) {
+        evt.preventDefault();
+        if (!dropdown) {
+          return;
+        }
+        var open = dropdown.classList.toggle(DROPDOWN_OPEN_CLASS);
+        profileToggle.setAttribute("aria-expanded", open ? "true" : "false");
+      });
+    }
+
+    if (logoutBtn && !logoutBtn.dataset.bound) {
+      logoutBtn.dataset.bound = "1";
+      logoutBtn.addEventListener("click", function () {
+        if (!authClient) {
+          logError("Auth client unavailable for logout.");
+          return;
+        }
+        authClient.logout({
+          returnTo: window.location.origin
+        });
+      });
+    }
+
+    if (!document.documentElement.dataset.dexAuthOutsideBound) {
+      document.documentElement.dataset.dexAuthOutsideBound = "1";
+      document.addEventListener("click", function (evt) {
+        if (!profileWrap || profileWrap.hidden) {
+          return;
+        }
+        var inside = profileWrap.contains(evt.target);
+        if (!inside) {
+          closeDropdown();
+        }
+      });
+    }
+  }
+
+  function parseAnchorFromClick(target) {
+    var node = target;
+    while (node && node !== document.documentElement) {
+      if (node.tagName && node.tagName.toLowerCase() === "a") {
+        return node;
+      }
+      node = node.parentNode;
+    }
+    return null;
+  }
+
+  function handleGuardedNavIntent(returnTo, cfg) {
+    if (!authClient) {
+      logError("Auth client unavailable for route guard redirect.");
+      return;
+    }
+    authClient.loginWithRedirect({
+      appState: { returnTo: returnTo },
+      redirect_uri: cfg.redirectUri
+    }).catch(function (err) {
+      logError("loginWithRedirect failed:", err);
+    });
+  }
+
+  function bindClickGuard(cfg) {
+    if (document.documentElement.dataset.dexAuthClickGuardBound) {
+      return;
+    }
+    document.documentElement.dataset.dexAuthClickGuardBound = "1";
+
+    document.addEventListener("click", function (evt) {
+      try {
+        var anchor = parseAnchorFromClick(evt.target);
+        if (!anchor) {
+          return;
+        }
+        var href = anchor.getAttribute("href");
+        if (!href || href.charAt(0) === "#") {
+          return;
+        }
+        var url = new URL(anchor.href, window.location.href);
+        if (url.origin !== window.location.origin) {
+          return;
+        }
+        if (!isProtectedPath(url.pathname)) {
+          return;
+        }
+        if (isAuthenticated) {
+          return;
+        }
+        evt.preventDefault();
+        evt.stopPropagation();
+        handleGuardedNavIntent(getReturnToFromUrl(url), cfg);
+      } catch (err) {
+        logError("Failed while guarding clicked link:", err);
+      }
+    }, true);
+  }
+
+  function clearAuthQueryParams() {
+    var url = new URL(window.location.href);
+    if (!url.searchParams.has("code") && !url.searchParams.has("state")) {
+      return;
+    }
+    url.searchParams.delete("code");
+    url.searchParams.delete("state");
+    var cleaned = url.pathname + (url.search ? url.search : "") + (url.hash ? url.hash : "");
+    window.history.replaceState({}, document.title, cleaned);
+  }
+
+  function getCurrentReturnTo() {
+    return window.location.pathname + window.location.search + window.location.hash;
+  }
+
+  async function init() {
+    try {
+      normalizeKnownProtectedLinks();
+      var cfgRoot = window.DEX_AUTH0_CONFIG;
+      var cfg = cfgRoot && cfgRoot.current;
+      ensureAuthUi();
+      if (!cfg) {
+        logError("Missing host Auth0 configuration; auth features disabled.");
+        bindUiEvents({ redirectUri: window.location.origin + "/auth/callback/" });
+        bindClickGuard({ redirectUri: window.location.origin + "/auth/callback/" });
+        return;
+      }
+      if (typeof window.createAuth0Client !== "function") {
+        logError("Auth0 SPA SDK missing; expected createAuth0Client global.");
+        bindUiEvents(cfg);
+        bindClickGuard(cfg);
+        return;
+      }
+
+      var createOptions = {
+        domain: cfg.domain,
+        client_id: cfg.clientId,
+        redirect_uri: cfg.redirectUri,
+        scope: "openid profile email"
+      };
+      if (cfg.audience) {
+        createOptions.audience = cfg.audience;
+      }
+
+      authClient = await window.createAuth0Client(createOptions);
+
+      if (isCallbackPath(window.location.pathname)) {
+        var callbackResult = await authClient.handleRedirectCallback();
+        clearAuthQueryParams();
+        var returnTo = (callbackResult && callbackResult.appState && callbackResult.appState.returnTo) || "/";
+        window.location.replace(returnTo);
+        return;
+      }
+
+      isAuthenticated = await authClient.isAuthenticated();
+      if (isProtectedPath(window.location.pathname) && !isAuthenticated) {
+        handleGuardedNavIntent(getCurrentReturnTo(), cfg);
+        return;
+      }
+
+      var user = null;
+      if (isAuthenticated) {
+        user = await authClient.getUser();
+      }
+      setUiState(isAuthenticated, user);
+      bindUiEvents(cfg);
+      bindClickGuard(cfg);
+    } catch (err) {
+      logError("Initialization error:", err);
+    }
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/assets/dex-auth0-config.js
+++ b/assets/dex-auth0-config.js
@@ -1,0 +1,33 @@
+(function () {
+  var host = window.location.hostname;
+  var byHost = {
+    "dexdsl.github.io": {
+      domain: "dexdsl.us.auth0.com",
+      clientId: "M92hIItt3XQPUvGvK0t2xDtLMCK1mVqc",
+      audience: "",
+      redirectUri: "https://dexdsl.github.io/auth/callback/"
+    },
+    "dexdsl.org": {
+      domain: "dexdsl.us.auth0.com",
+      clientId: "M92hIItt3XQPUvGvK0t2xDtLMCK1mVqc",
+      audience: "",
+      redirectUri: "https://dexdsl.org/auth/callback/"
+    },
+    "dexdsl.com": {
+      domain: "dexdsl.us.auth0.com",
+      clientId: "M92hIItt3XQPUvGvK0t2xDtLMCK1mVqc",
+      audience: "",
+      redirectUri: "https://dexdsl.com/auth/callback/"
+    }
+  };
+
+  var config = byHost[host] || null;
+  if (!config) {
+    console.warn("[dex-auth] No Auth0 config found for host:", host);
+  }
+
+  window.DEX_AUTH0_CONFIG = {
+    byHost: byHost,
+    current: config
+  };
+})();

--- a/entry/2-organs-midori-ataka/index.html
+++ b/entry/2-organs-midori-ataka/index.html
@@ -4,12 +4,12 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Dex — Protected (Dev Stub)</title>
-  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
-  <script defer src="/assets/dex-auth0-config.js"></script>
-  <script defer src="/assets/dex-auth.js"></script>
-  <style>
+<style>
     body { margin: 2rem; font-family: Arial, sans-serif; }
   </style>
+  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/1.19/auth0-spa-js.production.js"></script>
+  <script defer src="/assets/dex-auth0-config.js"></script>
+  <script defer src="/assets/dex-auth.js"></script>
 </head>
 <body>
   <h1>Dex — Protected (Dev Stub)</h1>

--- a/entry/achievements/index.html
+++ b/entry/achievements/index.html
@@ -3,12 +3,10 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Dex — Signing in...</title>
+  <title>Dex — Protected (Dev Stub)</title>
   <script defer src="https://cdn.auth0.com/js/auth0-spa-js/1.19/auth0-spa-js.production.js"></script>
   <script defer src="/assets/dex-auth0-config.js"></script>
   <script defer src="/assets/dex-auth.js"></script>
 </head>
-<body style="font-family: Arial, sans-serif; margin: 2rem;">
-  <p>Signing you in…</p>
-</body>
+<body></body>
 </html>

--- a/entry/aidan-yeats/index.html
+++ b/entry/aidan-yeats/index.html
@@ -4,12 +4,12 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Dex — Protected (Dev Stub)</title>
-  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
-  <script defer src="/assets/dex-auth0-config.js"></script>
-  <script defer src="/assets/dex-auth.js"></script>
-  <style>
+<style>
     body { margin: 2rem; font-family: Arial, sans-serif; }
   </style>
+  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/1.19/auth0-spa-js.production.js"></script>
+  <script defer src="/assets/dex-auth0-config.js"></script>
+  <script defer src="/assets/dex-auth.js"></script>
 </head>
 <body>
   <h1>Dex — Protected (Dev Stub)</h1>

--- a/entry/amplified-knives-tyler-jordan/index.html
+++ b/entry/amplified-knives-tyler-jordan/index.html
@@ -4,12 +4,12 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Dex — Protected (Dev Stub)</title>
-  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
-  <script defer src="/assets/dex-auth0-config.js"></script>
-  <script defer src="/assets/dex-auth.js"></script>
-  <style>
+<style>
     body { margin: 2rem; font-family: Arial, sans-serif; }
   </style>
+  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/1.19/auth0-spa-js.production.js"></script>
+  <script defer src="/assets/dex-auth0-config.js"></script>
+  <script defer src="/assets/dex-auth.js"></script>
 </head>
 <body>
   <h1>Dex — Protected (Dev Stub)</h1>

--- a/entry/amplified-printer/index.html
+++ b/entry/amplified-printer/index.html
@@ -4,12 +4,12 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Dex — Protected (Dev Stub)</title>
-  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
-  <script defer src="/assets/dex-auth0-config.js"></script>
-  <script defer src="/assets/dex-auth.js"></script>
-  <style>
+<style>
     body { margin: 2rem; font-family: Arial, sans-serif; }
   </style>
+  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/1.19/auth0-spa-js.production.js"></script>
+  <script defer src="/assets/dex-auth0-config.js"></script>
+  <script defer src="/assets/dex-auth.js"></script>
 </head>
 <body>
   <h1>Dex — Protected (Dev Stub)</h1>

--- a/entry/amplified-tv-sam-pluta/index.html
+++ b/entry/amplified-tv-sam-pluta/index.html
@@ -4,12 +4,12 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Dex — Protected (Dev Stub)</title>
-  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
-  <script defer src="/assets/dex-auth0-config.js"></script>
-  <script defer src="/assets/dex-auth.js"></script>
-  <style>
+<style>
     body { margin: 2rem; font-family: Arial, sans-serif; }
   </style>
+  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/1.19/auth0-spa-js.production.js"></script>
+  <script defer src="/assets/dex-auth0-config.js"></script>
+  <script defer src="/assets/dex-auth.js"></script>
 </head>
 <body>
   <h1>Dex — Protected (Dev Stub)</h1>

--- a/entry/anant-shah/index.html
+++ b/entry/anant-shah/index.html
@@ -4,12 +4,12 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Dex — Protected (Dev Stub)</title>
-  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
-  <script defer src="/assets/dex-auth0-config.js"></script>
-  <script defer src="/assets/dex-auth.js"></script>
-  <style>
+<style>
     body { margin: 2rem; font-family: Arial, sans-serif; }
   </style>
+  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/1.19/auth0-spa-js.production.js"></script>
+  <script defer src="/assets/dex-auth0-config.js"></script>
+  <script defer src="/assets/dex-auth.js"></script>
 </head>
 <body>
   <h1>Dex — Protected (Dev Stub)</h1>

--- a/entry/andrew-chanover/index.html
+++ b/entry/andrew-chanover/index.html
@@ -4,12 +4,12 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Dex — Protected (Dev Stub)</title>
-  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
-  <script defer src="/assets/dex-auth0-config.js"></script>
-  <script defer src="/assets/dex-auth.js"></script>
-  <style>
+<style>
     body { margin: 2rem; font-family: Arial, sans-serif; }
   </style>
+  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/1.19/auth0-spa-js.production.js"></script>
+  <script defer src="/assets/dex-auth0-config.js"></script>
+  <script defer src="/assets/dex-auth.js"></script>
 </head>
 <body>
   <h1>Dex — Protected (Dev Stub)</h1>

--- a/entry/as-though-im-slipping/index.html
+++ b/entry/as-though-im-slipping/index.html
@@ -4,12 +4,12 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Dex — Protected (Dev Stub)</title>
-  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
-  <script defer src="/assets/dex-auth0-config.js"></script>
-  <script defer src="/assets/dex-auth.js"></script>
-  <style>
+<style>
     body { margin: 2rem; font-family: Arial, sans-serif; }
   </style>
+  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/1.19/auth0-spa-js.production.js"></script>
+  <script defer src="/assets/dex-auth0-config.js"></script>
+  <script defer src="/assets/dex-auth.js"></script>
 </head>
 <body>
   <h1>Dex — Protected (Dev Stub)</h1>

--- a/entry/bassoon-and-electronics/index.html
+++ b/entry/bassoon-and-electronics/index.html
@@ -4,12 +4,12 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Dex — Protected (Dev Stub)</title>
-  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
-  <script defer src="/assets/dex-auth0-config.js"></script>
-  <script defer src="/assets/dex-auth.js"></script>
-  <style>
+<style>
     body { margin: 2rem; font-family: Arial, sans-serif; }
   </style>
+  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/1.19/auth0-spa-js.production.js"></script>
+  <script defer src="/assets/dex-auth0-config.js"></script>
+  <script defer src="/assets/dex-auth.js"></script>
 </head>
 <body>
   <h1>Dex — Protected (Dev Stub)</h1>

--- a/entry/bojun-zhang/index.html
+++ b/entry/bojun-zhang/index.html
@@ -4,12 +4,12 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Dex — Protected (Dev Stub)</title>
-  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
-  <script defer src="/assets/dex-auth0-config.js"></script>
-  <script defer src="/assets/dex-auth.js"></script>
-  <style>
+<style>
     body { margin: 2rem; font-family: Arial, sans-serif; }
   </style>
+  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/1.19/auth0-spa-js.production.js"></script>
+  <script defer src="/assets/dex-auth0-config.js"></script>
+  <script defer src="/assets/dex-auth.js"></script>
 </head>
 <body>
   <h1>Dex — Protected (Dev Stub)</h1>

--- a/entry/cello-emmanuel-losa/index.html
+++ b/entry/cello-emmanuel-losa/index.html
@@ -4,12 +4,12 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Dex — Protected (Dev Stub)</title>
-  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
-  <script defer src="/assets/dex-auth0-config.js"></script>
-  <script defer src="/assets/dex-auth.js"></script>
-  <style>
+<style>
     body { margin: 2rem; font-family: Arial, sans-serif; }
   </style>
+  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/1.19/auth0-spa-js.production.js"></script>
+  <script defer src="/assets/dex-auth0-config.js"></script>
+  <script defer src="/assets/dex-auth.js"></script>
 </head>
 <body>
   <h1>Dex — Protected (Dev Stub)</h1>

--- a/entry/cybernetic-scat-paul-hermansen/index.html
+++ b/entry/cybernetic-scat-paul-hermansen/index.html
@@ -4,12 +4,12 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Dex — Protected (Dev Stub)</title>
-  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
-  <script defer src="/assets/dex-auth0-config.js"></script>
-  <script defer src="/assets/dex-auth.js"></script>
-  <style>
+<style>
     body { margin: 2rem; font-family: Arial, sans-serif; }
   </style>
+  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/1.19/auth0-spa-js.production.js"></script>
+  <script defer src="/assets/dex-auth0-config.js"></script>
+  <script defer src="/assets/dex-auth.js"></script>
 </head>
 <body>
   <h1>Dex — Protected (Dev Stub)</h1>

--- a/entry/electric-guitar-chris-mann/index.html
+++ b/entry/electric-guitar-chris-mann/index.html
@@ -4,12 +4,12 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Dex — Protected (Dev Stub)</title>
-  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
-  <script defer src="/assets/dex-auth0-config.js"></script>
-  <script defer src="/assets/dex-auth.js"></script>
-  <style>
+<style>
     body { margin: 2rem; font-family: Arial, sans-serif; }
   </style>
+  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/1.19/auth0-spa-js.production.js"></script>
+  <script defer src="/assets/dex-auth0-config.js"></script>
+  <script defer src="/assets/dex-auth.js"></script>
 </head>
 <body>
   <h1>Dex — Protected (Dev Stub)</h1>

--- a/entry/electric-guitar-pedals-ethan-bailey-gould/index.html
+++ b/entry/electric-guitar-pedals-ethan-bailey-gould/index.html
@@ -4,12 +4,12 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Dex — Protected (Dev Stub)</title>
-  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
-  <script defer src="/assets/dex-auth0-config.js"></script>
-  <script defer src="/assets/dex-auth.js"></script>
-  <style>
+<style>
     body { margin: 2rem; font-family: Arial, sans-serif; }
   </style>
+  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/1.19/auth0-spa-js.production.js"></script>
+  <script defer src="/assets/dex-auth0-config.js"></script>
+  <script defer src="/assets/dex-auth.js"></script>
 </head>
 <body>
   <h1>Dex — Protected (Dev Stub)</h1>

--- a/entry/hammered-dulcimer-cameron-church/index.html
+++ b/entry/hammered-dulcimer-cameron-church/index.html
@@ -4,12 +4,12 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Dex — Protected (Dev Stub)</title>
-  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
-  <script defer src="/assets/dex-auth0-config.js"></script>
-  <script defer src="/assets/dex-auth.js"></script>
-  <style>
+<style>
     body { margin: 2rem; font-family: Arial, sans-serif; }
   </style>
+  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/1.19/auth0-spa-js.production.js"></script>
+  <script defer src="/assets/dex-auth0-config.js"></script>
+  <script defer src="/assets/dex-auth.js"></script>
 </head>
 <body>
   <h1>Dex — Protected (Dev Stub)</h1>

--- a/entry/messages/index.html
+++ b/entry/messages/index.html
@@ -3,12 +3,10 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Dex — Signing in...</title>
+  <title>Dex — Protected (Dev Stub)</title>
   <script defer src="https://cdn.auth0.com/js/auth0-spa-js/1.19/auth0-spa-js.production.js"></script>
   <script defer src="/assets/dex-auth0-config.js"></script>
   <script defer src="/assets/dex-auth.js"></script>
 </head>
-<body style="font-family: Arial, sans-serif; margin: 2rem;">
-  <p>Signing you in…</p>
-</body>
+<body></body>
 </html>

--- a/entry/multiperc/index.html
+++ b/entry/multiperc/index.html
@@ -4,12 +4,12 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Dex — Protected (Dev Stub)</title>
-  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
-  <script defer src="/assets/dex-auth0-config.js"></script>
-  <script defer src="/assets/dex-auth.js"></script>
-  <style>
+<style>
     body { margin: 2rem; font-family: Arial, sans-serif; }
   </style>
+  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/1.19/auth0-spa-js.production.js"></script>
+  <script defer src="/assets/dex-auth0-config.js"></script>
+  <script defer src="/assets/dex-auth.js"></script>
 </head>
 <body>
   <h1>Dex — Protected (Dev Stub)</h1>

--- a/entry/no-input-mixer-jared-murphy/index.html
+++ b/entry/no-input-mixer-jared-murphy/index.html
@@ -4,12 +4,12 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Dex — Protected (Dev Stub)</title>
-  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
-  <script defer src="/assets/dex-auth0-config.js"></script>
-  <script defer src="/assets/dex-auth.js"></script>
-  <style>
+<style>
     body { margin: 2rem; font-family: Arial, sans-serif; }
   </style>
+  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/1.19/auth0-spa-js.production.js"></script>
+  <script defer src="/assets/dex-auth0-config.js"></script>
+  <script defer src="/assets/dex-auth.js"></script>
 </head>
 <body>
   <h1>Dex — Protected (Dev Stub)</h1>

--- a/entry/prepared-bass-viol-suarez-solis/index.html
+++ b/entry/prepared-bass-viol-suarez-solis/index.html
@@ -4,12 +4,12 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Dex — Protected (Dev Stub)</title>
-  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
-  <script defer src="/assets/dex-auth0-config.js"></script>
-  <script defer src="/assets/dex-auth.js"></script>
-  <style>
+<style>
     body { margin: 2rem; font-family: Arial, sans-serif; }
   </style>
+  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/1.19/auth0-spa-js.production.js"></script>
+  <script defer src="/assets/dex-auth0-config.js"></script>
+  <script defer src="/assets/dex-auth.js"></script>
 </head>
 <body>
   <h1>Dex — Protected (Dev Stub)</h1>

--- a/entry/prepared-harpsichord-suarez-solis/index.html
+++ b/entry/prepared-harpsichord-suarez-solis/index.html
@@ -4,12 +4,12 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Dex — Protected (Dev Stub)</title>
-  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
-  <script defer src="/assets/dex-auth0-config.js"></script>
-  <script defer src="/assets/dex-auth.js"></script>
-  <style>
+<style>
     body { margin: 2rem; font-family: Arial, sans-serif; }
   </style>
+  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/1.19/auth0-spa-js.production.js"></script>
+  <script defer src="/assets/dex-auth0-config.js"></script>
+  <script defer src="/assets/dex-auth.js"></script>
 </head>
 <body>
   <h1>Dex — Protected (Dev Stub)</h1>

--- a/entry/prepared-oboe-sky-macklay/index.html
+++ b/entry/prepared-oboe-sky-macklay/index.html
@@ -4,12 +4,12 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Dex — Protected (Dev Stub)</title>
-  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
-  <script defer src="/assets/dex-auth0-config.js"></script>
-  <script defer src="/assets/dex-auth.js"></script>
-  <style>
+<style>
     body { margin: 2rem; font-family: Arial, sans-serif; }
   </style>
+  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/1.19/auth0-spa-js.production.js"></script>
+  <script defer src="/assets/dex-auth0-config.js"></script>
+  <script defer src="/assets/dex-auth.js"></script>
 </head>
 <body>
   <h1>Dex — Protected (Dev Stub)</h1>

--- a/entry/pressroom/index.html
+++ b/entry/pressroom/index.html
@@ -3,12 +3,10 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Dex — Signing in...</title>
+  <title>Dex — Protected (Dev Stub)</title>
   <script defer src="https://cdn.auth0.com/js/auth0-spa-js/1.19/auth0-spa-js.production.js"></script>
   <script defer src="/assets/dex-auth0-config.js"></script>
   <script defer src="/assets/dex-auth.js"></script>
 </head>
-<body style="font-family: Arial, sans-serif; margin: 2rem;">
-  <p>Signing you in…</p>
-</body>
+<body></body>
 </html>

--- a/entry/sebastian-suarez-solis/index.html
+++ b/entry/sebastian-suarez-solis/index.html
@@ -4,12 +4,12 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Dex — Protected (Dev Stub)</title>
-  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
-  <script defer src="/assets/dex-auth0-config.js"></script>
-  <script defer src="/assets/dex-auth.js"></script>
-  <style>
+<style>
     body { margin: 2rem; font-family: Arial, sans-serif; }
   </style>
+  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/1.19/auth0-spa-js.production.js"></script>
+  <script defer src="/assets/dex-auth0-config.js"></script>
+  <script defer src="/assets/dex-auth.js"></script>
 </head>
 <body>
   <h1>Dex — Protected (Dev Stub)</h1>

--- a/entry/splinterings-jakob-heinemann/index.html
+++ b/entry/splinterings-jakob-heinemann/index.html
@@ -4,12 +4,12 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Dex — Protected (Dev Stub)</title>
-  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
-  <script defer src="/assets/dex-auth0-config.js"></script>
-  <script defer src="/assets/dex-auth.js"></script>
-  <style>
+<style>
     body { margin: 2rem; font-family: Arial, sans-serif; }
   </style>
+  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/1.19/auth0-spa-js.production.js"></script>
+  <script defer src="/assets/dex-auth0-config.js"></script>
+  <script defer src="/assets/dex-auth.js"></script>
 </head>
 <body>
   <h1>Dex — Protected (Dev Stub)</h1>

--- a/entry/submit/index.html
+++ b/entry/submit/index.html
@@ -3,12 +3,10 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Dex — Signing in...</title>
+  <title>Dex — Protected (Dev Stub)</title>
   <script defer src="https://cdn.auth0.com/js/auth0-spa-js/1.19/auth0-spa-js.production.js"></script>
   <script defer src="/assets/dex-auth0-config.js"></script>
   <script defer src="/assets/dex-auth.js"></script>
 </head>
-<body style="font-family: Arial, sans-serif; margin: 2rem;">
-  <p>Signing you in…</p>
-</body>
+<body></body>
 </html>

--- a/entry/this-is-a-tangible-space/index.html
+++ b/entry/this-is-a-tangible-space/index.html
@@ -4,12 +4,12 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Dex — Protected (Dev Stub)</title>
-  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
-  <script defer src="/assets/dex-auth0-config.js"></script>
-  <script defer src="/assets/dex-auth.js"></script>
-  <style>
+<style>
     body { margin: 2rem; font-family: Arial, sans-serif; }
   </style>
+  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/1.19/auth0-spa-js.production.js"></script>
+  <script defer src="/assets/dex-auth0-config.js"></script>
+  <script defer src="/assets/dex-auth.js"></script>
 </head>
 <body>
   <h1>Dex — Protected (Dev Stub)</h1>

--- a/entry/tim-feeney/index.html
+++ b/entry/tim-feeney/index.html
@@ -4,12 +4,12 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Dex — Protected (Dev Stub)</title>
-  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
-  <script defer src="/assets/dex-auth0-config.js"></script>
-  <script defer src="/assets/dex-auth.js"></script>
-  <style>
+<style>
     body { margin: 2rem; font-family: Arial, sans-serif; }
   </style>
+  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/1.19/auth0-spa-js.production.js"></script>
+  <script defer src="/assets/dex-auth0-config.js"></script>
+  <script defer src="/assets/dex-auth.js"></script>
 </head>
 <body>
   <h1>Dex — Protected (Dev Stub)</h1>

--- a/entry/voice-everyday-object-manipulation-levi-lu/index.html
+++ b/entry/voice-everyday-object-manipulation-levi-lu/index.html
@@ -4,12 +4,12 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Dex — Protected (Dev Stub)</title>
-  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
-  <script defer src="/assets/dex-auth0-config.js"></script>
-  <script defer src="/assets/dex-auth.js"></script>
-  <style>
+<style>
     body { margin: 2rem; font-family: Arial, sans-serif; }
   </style>
+  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/1.19/auth0-spa-js.production.js"></script>
+  <script defer src="/assets/dex-auth0-config.js"></script>
+  <script defer src="/assets/dex-auth.js"></script>
 </head>
 <body>
   <h1>Dex — Protected (Dev Stub)</h1>

--- a/polls/index.html
+++ b/polls/index.html
@@ -3,12 +3,10 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Dex — Signing in...</title>
+  <title>Dex — Protected (Dev Stub)</title>
   <script defer src="https://cdn.auth0.com/js/auth0-spa-js/1.19/auth0-spa-js.production.js"></script>
   <script defer src="/assets/dex-auth0-config.js"></script>
   <script defer src="/assets/dex-auth.js"></script>
 </head>
-<body style="font-family: Arial, sans-serif; margin: 2rem;">
-  <p>Signing you in…</p>
-</body>
+<body></body>
 </html>

--- a/press/index.html
+++ b/press/index.html
@@ -4,12 +4,12 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Dex — Protected (Dev Stub)</title>
-  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js"></script>
-  <script defer src="/assets/dex-auth0-config.js"></script>
-  <script defer src="/assets/dex-auth.js"></script>
-  <style>
+<style>
     body { margin: 2rem; font-family: Arial, sans-serif; }
   </style>
+  <script defer src="https://cdn.auth0.com/js/auth0-spa-js/1.19/auth0-spa-js.production.js"></script>
+  <script defer src="/assets/dex-auth0-config.js"></script>
+  <script defer src="/assets/dex-auth.js"></script>
 </head>
 <body>
   <h1>Dex — Protected (Dev Stub)</h1>

--- a/scripts/generate-protected-route-stubs.py
+++ b/scripts/generate-protected-route-stubs.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+ROUTES = [
+    "press",
+    "polls",
+    "entry/submit",
+    "entry/messages",
+    "entry/achievements",
+    "entry/pressroom",
+    "entry/2-organs-midori-ataka",
+    "entry/aidan-yeats",
+    "entry/amplified-knives-tyler-jordan",
+    "entry/amplified-printer",
+    "entry/amplified-tv-sam-pluta",
+    "entry/anant-shah",
+    "entry/andrew-chanover",
+    "entry/as-though-im-slipping",
+    "entry/bassoon-and-electronics",
+    "entry/bojun-zhang",
+    "entry/cello-emmanuel-losa",
+    "entry/cybernetic-scat-paul-hermansen",
+    "entry/electric-guitar-chris-mann",
+    "entry/electric-guitar-pedals-ethan-bailey-gould",
+    "entry/hammered-dulcimer-cameron-church",
+    "entry/multiperc",
+    "entry/no-input-mixer-jared-murphy",
+    "entry/prepared-bass-viol-suarez-solis",
+    "entry/prepared-harpsichord-suarez-solis",
+    "entry/prepared-oboe-sky-macklay",
+    "entry/sebastian-suarez-solis",
+    "entry/splinterings-jakob-heinemann",
+    "entry/this-is-a-tangible-space",
+    "entry/tim-feeney",
+    "entry/voice-everyday-object-manipulation-levi-lu",
+]
+
+STUB = """<!doctype html>
+<html lang=\"en\">
+<head>
+  <meta charset=\"utf-8\">
+  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">
+  <title>Dex — Protected (Dev Stub)</title>
+  <script defer src=\"https://cdn.auth0.com/js/auth0-spa-js/1.19/auth0-spa-js.production.js\"></script>
+  <script defer src=\"/assets/dex-auth0-config.js\"></script>
+  <script defer src=\"/assets/dex-auth.js\"></script>
+</head>
+<body></body>
+</html>
+"""
+
+for route in ROUTES:
+    p = Path(route) / "index.html"
+    if p.exists():
+        continue
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(STUB, encoding="utf-8")
+    print(f"created {p}")

--- a/scripts/inject-auth-scripts.py
+++ b/scripts/inject-auth-scripts.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+import re
+from pathlib import Path
+
+AUTH0_SCRIPT = '<script defer src="https://cdn.auth0.com/js/auth0-spa-js/1.19/auth0-spa-js.production.js"></script>'
+CFG_SCRIPT = '<script defer src="/assets/dex-auth0-config.js"></script>'
+AUTH_SCRIPT = '<script defer src="/assets/dex-auth.js"></script>'
+BLOCK = f"  {AUTH0_SCRIPT}\n  {CFG_SCRIPT}\n  {AUTH_SCRIPT}\n"
+
+SCRIPT_PATTERNS = [
+    re.compile(r"\s*<script[^>]*src=\"https://cdn\.auth0\.com/js/auth0-spa-js/[^\"]+\"[^>]*></script>\s*", re.IGNORECASE),
+    re.compile(r"\s*<script[^>]*src=\"/assets/dex-auth0-config\.js\"[^>]*></script>\s*", re.IGNORECASE),
+    re.compile(r"\s*<script[^>]*src=\"/assets/dex-auth\.js\"[^>]*></script>\s*", re.IGNORECASE),
+]
+
+for p in Path('.').rglob('*.html'):
+    if 'node_modules' in p.parts or '.git' in p.parts:
+        continue
+    original = p.read_text(encoding='utf-8')
+    text = original
+    for pattern in SCRIPT_PATTERNS:
+      text = pattern.sub('\n', text)
+
+    if re.search(r"</head>", text, re.IGNORECASE):
+        text = re.sub(r"</head>", BLOCK + "</head>", text, count=1, flags=re.IGNORECASE)
+
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    if text != original:
+        p.write_text(text, encoding='utf-8')
+        print(f"updated {p}")


### PR DESCRIPTION
### Motivation
- The site was loading a mix of Auth0 SPA SDK versions and using v2-style options, producing malformed `/authorize` requests (`authorizationParams=[object Object]` / missing `client_id`).
- The goal is to standardize on Auth0 SPA JS v1.x and make the client-side auth flow and protected-route handling static-safe for GitHub Pages.

### Description
- Standardized runtime auth to Auth0 SPA JS v1 shapes in `assets/dex-auth.js`, using `client_id`, `redirect_uri`, `scope`, and optional `audience` for `createAuth0Client` and using top-level `redirect_uri` + `appState.returnTo` for `loginWithRedirect` and `handleRedirectCallback` for callback completion.
- Published root-served auth files so Pages can load them at `/assets/dex-auth.js` and `/assets/dex-auth0-config.js` and updated pages to include the v1 CDN script `https://cdn.auth0.com/js/auth0-spa-js/1.19/auth0-spa-js.production.js` plus the two assets.
- Added link-normalization for known protected routes and ensured dropdown links are root-absolute (e.g. `/polls/`, `/entry/submit/`, `/entry/messages/`, `/entry/pressroom/`, `/entry/achievements/`, `/press/`).
- Added GitHub Pages–safe stubs (idempotent) for all protected routes listed and an `/auth/callback/` page that runs the same auth assets and completes the redirect; created helper scripts `scripts/generate-protected-route-stubs.py` and `scripts/inject-auth-scripts.py` to generate stubs and to idempotently inject the canonical script block into HTML files.

### Testing
- Ran JavaScript syntax check: `node --check assets/dex-auth.js` which succeeded.
- Verified all listed protected route `index.html` files exist by re-running the stub generator (`python scripts/generate-protected-route-stubs.py`) and confirming no missing routes.
- Ensured pages load the single v1 SDK include by searching for `auth0-spa-js/1.19` and that `auth0-spa-js/2.0` is no longer present on the updated stubs and callback page.
- Performed a local static server run and captured a Playwright screenshot of `http://127.0.0.1:8000/entry/tim-feeney/` to validate the stub loads the v1 script and assets (succeeded).
- Confirmed the runtime now builds `createAuth0Client` options with `client_id` and `redirect_uri` and that `loginWithRedirect` calls pass `redirect_uri` and `appState.returnTo` so the `/authorize` URL will include `client_id=` and `redirect_uri=` instead of `clientId=` or `authorizationParams=[object Object]`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997dcf912d08327a7ff07db2b3d7a03)