### PR TITLE
Fix auth header avatar fallback, vertical alignment, and logout styling

### DIFF
--- a/docs/assets/dex-auth.js
+++ b/docs/assets/dex-auth.js
@@ -92,7 +92,7 @@
       + '<button id="auth-ui-signin" class="dex-auth-fallback-btn" type="button">SIGN IN</button>'
       + '<div id="auth-ui-profile" hidden>'
       + '  <button id="auth-ui-profile-toggle" type="button" aria-haspopup="true" aria-expanded="false" title="Profile">'
-      + '    <img id="auth-ui-avatar" alt="Profile avatar" src="data:image/gif;base64,R0lGODlhAQABAAAAACw=">'
+      + '    <span class="dex-avatar-wrap"><img id="auth-ui-avatar" alt="Profile avatar" src=""></span>'
       + '    <span class="dex-profile-chevron" aria-hidden="true"></span>'
       + "  </button>"
       + '  <div id="auth-ui-dropdown" role="menu" aria-label="Account menu">'
@@ -110,6 +110,28 @@
       + '    <button id="auth-ui-logout" class="dex-menu-item is-logout" type="button" role="menuitem">Log out</button>'
       + "  </div>"
       + "</div>";
+  }
+
+  function getDefaultAvatarDataUri(name) {
+    var label = typeof name === "string" ? name.trim() : "";
+    var initials = "U";
+    if (label) {
+      var parts = label.split(/\s+/).filter(Boolean);
+      if (parts.length > 1) {
+        initials = (parts[0].charAt(0) + parts[1].charAt(0)).toUpperCase();
+      } else {
+        initials = parts[0].slice(0, 2).toUpperCase();
+      }
+    }
+    var safeInitials = initials.replace(/[^A-Z0-9]/gi, "").slice(0, 2) || "U";
+    var svg = ""
+      + '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Avatar">'
+      + '<defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#8cb4ff"/><stop offset="100%" stop-color="#5a78d8"/></linearGradient></defs>'
+      + '<rect width="64" height="64" rx="32" fill="url(#g)"/>'
+      + '<circle cx="32" cy="24" r="12" fill="rgba(255,255,255,0.22)"/>'
+      + '<text x="32" y="42" text-anchor="middle" fill="#ffffff" font-family="Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif" font-size="22" font-weight="700">' + safeInitials + "</text>"
+      + "</svg>";
+    return "data:image/svg+xml;charset=UTF-8," + encodeURIComponent(svg);
   }
     function getCreateAuth0ClientFn() {
       if (typeof window.createAuth0Client === "function") return window.createAuth0Client;
@@ -249,7 +271,7 @@
       var style = document.createElement("style");
       style.id = styleId;
       style.textContent = ""
-        + "#auth-ui{--dex-text:rgba(255,255,255,.92);--dex-text-muted:rgba(255,255,255,.78);--dex-panel-bg:linear-gradient(155deg,rgba(255,255,255,.14),rgba(255,255,255,.1) 42%,rgba(20,24,34,.62));--dex-row-bg:linear-gradient(145deg,rgba(255,255,255,.14),rgba(255,255,255,.06));--dex-row-hover-bg:linear-gradient(140deg,rgba(255,255,255,.2),rgba(255,255,255,.1));--dex-border:rgba(255,255,255,.14);--dex-border-strong:rgba(255,255,255,.26);--dex-shadow:0 16px 44px rgba(0,0,0,.22);--dex-grain-opacity:.08;--dex-text-shadow:0 1px 1px rgba(0,0,0,.22);--dex-signin-bg:linear-gradient(135deg,rgba(125,164,255,.94),rgba(91,134,244,.9));--dex-signin-border:rgba(160,192,255,.54);--dex-signin-shadow:0 8px 22px rgba(40,76,165,.28);--dex-radius:10px;--dex-nav-h:38px;--dex-space-2:var(--space-2,8px);--dex-space-3:var(--space-3,12px);position:relative;top:0;display:inline-flex;align-items:center;align-self:center;vertical-align:middle;line-height:1;overflow:visible;padding:0;margin:0;gap:var(--dex-space-2);font-family:inherit;color:var(--dex-text);}"
+        + "#auth-ui{--dex-text:rgba(255,255,255,.92);--dex-text-muted:rgba(255,255,255,.78);--dex-panel-bg:linear-gradient(155deg,rgba(255,255,255,.14),rgba(255,255,255,.1) 42%,rgba(20,24,34,.62));--dex-row-bg:linear-gradient(145deg,rgba(255,255,255,.14),rgba(255,255,255,.06));--dex-row-hover-bg:linear-gradient(140deg,rgba(255,255,255,.2),rgba(255,255,255,.1));--dex-border:rgba(255,255,255,.14);--dex-border-strong:rgba(255,255,255,.26);--dex-shadow:0 16px 44px rgba(0,0,0,.22);--dex-grain-opacity:.08;--dex-text-shadow:0 1px 1px rgba(0,0,0,.22);--dex-signin-bg:linear-gradient(135deg,rgba(125,164,255,.94),rgba(91,134,244,.9));--dex-signin-border:rgba(160,192,255,.54);--dex-signin-shadow:0 8px 22px rgba(40,76,165,.28);--dex-radius:10px;--dex-nav-h:38px;--dex-space-2:var(--space-2,8px);--dex-space-3:var(--space-3,12px);position:relative;top:0;display:inline-flex;align-items:center;align-self:center;vertical-align:middle;line-height:1;overflow:visible;padding:0;margin:0;gap:var(--dex-space-2);font-family:inherit;color:var(--dex-text);transform:translateY(var(--dex-nav-offset-y,0px));}"
         + "#auth-ui[data-dex-scheme='dark']{--dex-text:rgba(255,255,255,.92);--dex-text-muted:rgba(245,248,255,.84);--dex-panel-bg:linear-gradient(155deg,rgba(255,255,255,.14),rgba(255,255,255,.1) 42%,rgba(20,24,34,.62));--dex-row-bg:linear-gradient(145deg,rgba(255,255,255,.14),rgba(255,255,255,.06));--dex-row-hover-bg:linear-gradient(140deg,rgba(255,255,255,.2),rgba(255,255,255,.1));--dex-border:rgba(255,255,255,.14);--dex-border-strong:rgba(255,255,255,.28);--dex-shadow:0 16px 44px rgba(0,0,0,.22);--dex-grain-opacity:.08;--dex-text-shadow:0 1px 1px rgba(0,0,0,.22);--dex-signin-bg:linear-gradient(135deg,rgba(125,164,255,.94),rgba(91,134,244,.9));--dex-signin-border:rgba(160,192,255,.54);--dex-signin-shadow:0 8px 22px rgba(40,76,165,.28);}"
         + "#auth-ui[data-dex-scheme='light']{--dex-text:rgba(15,18,25,.92);--dex-text-muted:rgba(28,35,52,.76);--dex-panel-bg:linear-gradient(150deg,rgba(255,255,255,.82),rgba(249,252,255,.72) 46%,rgba(238,244,255,.66));--dex-row-bg:linear-gradient(145deg,rgba(255,255,255,.72),rgba(246,250,255,.62));--dex-row-hover-bg:linear-gradient(145deg,rgba(255,255,255,.9),rgba(237,244,255,.75));--dex-border:rgba(15,18,25,.1);--dex-border-strong:rgba(15,18,25,.22);--dex-shadow:0 14px 36px rgba(0,0,0,.12);--dex-grain-opacity:0;--dex-text-shadow:none;--dex-signin-bg:linear-gradient(135deg,rgba(83,122,224,.96),rgba(63,97,192,.92));--dex-signin-border:rgba(39,64,130,.26);--dex-signin-shadow:0 7px 18px rgba(42,73,149,.22);}"
         + "#auth-ui,#auth-ui *,#auth-ui *::before,#auth-ui *::after{box-sizing:border-box;}"
@@ -260,11 +282,12 @@
         + "#auth-ui-signin.dex-auth-fallback-btn:focus-visible,#auth-ui-profile-toggle:focus-visible,#auth-ui-dropdown .dex-menu-item:focus-visible{outline:none;box-shadow:0 0 0 2px rgba(125,170,255,.45),0 0 0 4px rgba(22,26,38,.45);}"
         + "#auth-ui-profile{position:relative;display:inline-flex;align-items:center;overflow:visible;}"
         + "#auth-ui-profile-toggle{position:relative;gap:0;border:1px solid var(--dex-border);background:var(--dex-row-bg);width:var(--dex-nav-h,38px);min-width:var(--dex-nav-h,38px);border-radius:var(--dex-radius);cursor:pointer;padding:2px 16px 2px 2px;backdrop-filter:blur(8px) saturate(132%);-webkit-backdrop-filter:blur(8px) saturate(132%);transition:border-color .22s ease,filter .22s ease,background .22s ease;overflow:hidden;}"
-        + "#auth-ui-profile-toggle::before{content:'';position:absolute;inset:-30%;background:radial-gradient(circle at 20% 20%,rgba(255,255,255,.35),rgba(255,255,255,0) 55%);opacity:0;transition:opacity .22s ease;}"
+        + "#auth-ui-profile-toggle::before{content:'';position:absolute;inset:-30%;background:radial-gradient(circle at 20% 20%,rgba(255,255,255,.35),rgba(255,255,255,0) 55%);opacity:0;transition:opacity .22s ease;z-index:0;}"
         + "#auth-ui-profile-toggle:hover{border-color:var(--dex-border-strong);filter:brightness(1.02);background:var(--dex-row-hover-bg);}"
         + "#auth-ui-profile-toggle:hover::before{opacity:1;}"
-        + "#auth-ui-avatar{width:100%;height:100%;border-radius:9999px;object-fit:cover;display:block;pointer-events:none;}"
-        + "#auth-ui .dex-profile-chevron{position:absolute;right:7px;top:50%;width:8px;height:8px;border-right:1.5px solid var(--dex-text-muted);border-bottom:1.5px solid var(--dex-text-muted);transform:translateY(-60%) rotate(45deg);opacity:.95;transition:transform .2s ease,border-color .2s ease;pointer-events:none;}"
+        + ".dex-avatar-wrap{position:relative;z-index:1;flex:0 0 auto;width:calc(var(--dex-nav-h,38px) - 6px);height:calc(var(--dex-nav-h,38px) - 6px);border-radius:999px;overflow:hidden;}"
+        + "#auth-ui-avatar{width:100%;height:100%;display:block;object-fit:cover;}"
+        + "#auth-ui .dex-profile-chevron{position:absolute;right:7px;top:50%;width:8px;height:8px;border-right:1.5px solid var(--dex-text-muted);border-bottom:1.5px solid var(--dex-text-muted);transform:translateY(-60%) rotate(45deg);opacity:.95;transition:transform .2s ease,border-color .2s ease;pointer-events:none;z-index:2;}"
         + "#auth-ui-dropdown{position:absolute;right:0;top:calc(100% + 10px);width:min(280px,calc(100vw - 20px));max-width:calc(100vw - 20px);max-height:min(70vh,420px);overflow:auto;border:1px solid var(--dex-border);border-top-color:var(--dex-border-strong);border-radius:calc(var(--dex-radius) + 2px);background:var(--dex-panel-bg);box-shadow:var(--dex-shadow);padding:var(--dex-space-2);z-index:1200;opacity:0;transform:translateY(-6px) scale(.985);pointer-events:none;backdrop-filter:blur(12px) saturate(140%);-webkit-backdrop-filter:blur(12px) saturate(140%);transition:opacity .2s ease,transform .2s ease;}"
         + "#auth-ui-dropdown::after{content:'';position:absolute;inset:0;border-radius:inherit;background-image:radial-gradient(rgba(255,255,255,.05) 0.7px,transparent .7px);background-size:3px 3px;opacity:var(--dex-grain-opacity);pointer-events:none;}"
         + "#auth-ui-dropdown." + DROPDOWN_OPEN_CLASS + "{opacity:1;transform:translateY(0) scale(1);pointer-events:auto;}"
@@ -273,7 +296,8 @@
         + "#auth-ui .dex-menu-item:hover{transform:translateY(-1px);border-color:var(--dex-border-strong);background:var(--dex-row-hover-bg);}"
         + "#auth-ui .dex-menu-item:hover::before{transform:translateX(130%);}"
         + "#auth-ui .dex-menu-sep{height:1px;background:linear-gradient(90deg,transparent,var(--dex-border-strong),transparent);margin:8px 2px 10px;}"
-        + "#auth-ui #auth-ui-logout{margin-bottom:0;color:rgba(255,196,196,.98);border-color:rgba(255,160,160,.25);}"
+        + "#auth-ui .dex-menu-item.is-logout,#auth-ui #auth-ui-logout{margin-bottom:0;color:rgba(255,255,255,0.92);background:linear-gradient(180deg,rgba(0,0,0,0.78),rgba(0,0,0,0.62));border-color:rgba(255,255,255,0.16);}"
+        + "#auth-ui .dex-menu-item.is-logout:hover,#auth-ui #auth-ui-logout:hover{background:linear-gradient(180deg,rgba(0,0,0,0.86),rgba(0,0,0,0.70));border-color:rgba(255,255,255,0.24);}"
         + "#auth-ui-profile-toggle[aria-expanded='true'] .dex-profile-chevron{transform:translateY(-45%) rotate(225deg);border-color:var(--dex-text);}"
         + "#auth-ui-profile-toggle[aria-expanded='true']{border-color:var(--dex-border-strong);filter:brightness(1.03);}"
         + "@supports not ((-webkit-backdrop-filter:blur(1px)) or (backdrop-filter:blur(1px))){#auth-ui-profile-toggle,#auth-ui-dropdown{background:rgba(28,32,45,.9);}#auth-ui[data-dex-scheme='light'] #auth-ui-profile-toggle,#auth-ui[data-dex-scheme='light'] #auth-ui-dropdown{background:rgba(252,252,255,.95);}}"
@@ -351,6 +375,13 @@
       if (navHeight > 0) {
         ui.style.setProperty("--dex-nav-h", Math.round(navHeight) + "px");
       }
+      var refRect = ref.getBoundingClientRect();
+      var uiRect = ui.getBoundingClientRect();
+      var dy = (refRect.top + (refRect.height / 2)) - (uiRect.top + (uiRect.height / 2));
+      dy = Math.max(-12, Math.min(12, dy));
+      ui.style.setProperty("--dex-nav-offset-y", Math.round(dy) + "px");
+    } else {
+      ui.style.setProperty("--dex-nav-offset-y", "0px");
     }
     var bgTarget = findHeaderBackgroundElement(mount || ui.parentElement || pickMount());
     var bgRgb = getEffectiveBackgroundColor(bgTarget);
@@ -493,15 +524,15 @@
     }
 
     applyPrimaryButtonStyle(signInBtn);
+    var fallbackAvatar = getDefaultAvatarDataUri(user && user.name);
+    avatar.src = fallbackAvatar;
 
     if (auth) {
       signInBtn.hidden = true;
       signInBtn.setAttribute("hidden", "hidden");
       profileWrap.hidden = false;
       profileWrap.removeAttribute("hidden");
-      if (user && user.picture) {
-        avatar.src = user.picture;
-      }
+      avatar.src = (user && user.picture) ? user.picture : fallbackAvatar;
       if (user && user.name) {
         profileToggle.title = user.name;
       }


### PR DESCRIPTION
### Motivation
- Repair header UI regressions so the profile avatar never appears blank, the SIGN IN / profile controls vertically align with sibling nav items, and the Log out row uses a white-on-black glass look.
- Keep all IDs, menu links and Auth0 logic unchanged while applying only localized UI fixes in `docs/assets/dex-auth.js`.

### Description
- Wrap the avatar image in a stable container by replacing the raw `<img id="auth-ui-avatar">` with `<span class="dex-avatar-wrap"><img id="auth-ui-avatar" ...></span>` to enforce sizing and layering.
- Add `getDefaultAvatarDataUri(name)` and use it in `setUiState(...)` so `#auth-ui-avatar` always has a visible SVG data-URI fallback (initials + subtle gradient) when `user.picture` is missing or when signed out.
- Update injected CSS to add `.dex-avatar-wrap`, ensure proper `object-fit` for the image, adjust z-indexes so the profile-toggle sheen cannot wash out the avatar, and apply `transform: translateY(var(--dex-nav-offset-y,0px))` on `#auth-ui` for centerline alignment.
- Extend `syncAuthUiMetrics(...)` to compute a clamped vertical offset (`--dex-nav-offset-y`) from a visible sibling nav reference and set it so the auth controls snap to the same centerline as other header items.
- Restyle the logout row targeting `.dex-menu-item.is-logout` / `#auth-ui-logout` to be white text on a near-black glass background with adjusted border and hover states, removing the prior warm/destructive tint.

### Testing
- Ran `node --check docs/assets/dex-auth.js` and it completed successfully.
- Served the `docs` directory with `python3 -m http.server` and used an automated Playwright script to load the page and capture a screenshot of the header UI; the screenshot was generated successfully for visual verification.
- No automated unit tests were present for this file; changes were validated via the static-check and automated visual capture described above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69980e46878883278c6fc55b48173443)