### PR TITLE
Implement interactive `dex init` wizard with deterministic template injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-test
+# dex CLI
+
+## Quick start
+
+1. `npm i`
+2. Run locally: `node scripts/dex.mjs init`
+3. Or via npm script: `npm run dex -- init`
+4. Optional global linking during development:
+   - `npm link`
+   - `dex init`
+
+`dex init` uses `./index.html` in your current folder by default. If needed, pass `--template <path>`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "dependencies": {
         "cheerio": "^1.0.0",
         "commander": "^12.1.0",
+        "prompts": "^2.4.2",
         "zod": "^3.23.8"
       },
       "bin": {
@@ -241,6 +242,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/nth-check": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
@@ -334,10 +344,29 @@
         "node": ">=18"
       }
     },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
     },
     "node_modules/undici": {

--- a/package.json
+++ b/package.json
@@ -4,10 +4,12 @@
   "type": "module",
   "scripts": {
     "rewrite:anchors": "node scripts/rewrite-internal-anchors.mjs",
-    "check:anchors": "node scripts/rewrite-internal-anchors.mjs --check"
+    "check:anchors": "node scripts/rewrite-internal-anchors.mjs --check",
+    "dex": "node scripts/dex.mjs",
+    "smoke:dex-init": "node scripts/smoke-dex-init.mjs"
   },
   "bin": {
-      "dex": "scripts/dex.mjs"
+    "dex": "scripts/dex.mjs"
   },
   "devDependencies": {
     "parse5": "^7.3.0",
@@ -16,6 +18,7 @@
   "dependencies": {
     "commander": "^12.1.0",
     "cheerio": "^1.0.0",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "prompts": "^2.4.2"
   }
 }

--- a/scripts/lib/entry-html.mjs
+++ b/scripts/lib/entry-html.mjs
@@ -1,0 +1,141 @@
+import { load } from 'cheerio';
+
+const MARKERS = {
+  video: ['DEX:VIDEO_START', 'DEX:VIDEO_END'],
+  desc: ['DEX:DESC_START', 'DEX:DESC_END'],
+  sidebar: ['DEX:SIDEBAR_PAGE_CONFIG_START', 'DEX:SIDEBAR_PAGE_CONFIG_END'],
+};
+
+const AUTH_CANDIDATES = ['/assets/dex-auth0-config.js', '/assets/dex-auth-config.js'];
+const AUTH_CDN = 'https://cdn.auth0.com/js/auth0-spa-js/2.0/auth0-spa-js.production.js';
+
+const esc = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+function markerTokens(html, key) {
+  const [startCore, endCore] = MARKERS[key];
+  const starts = [`<!-- ${startCore} -->`, `<!-- @-- ${startCore} --@ -->`];
+  const ends = [`<!-- ${endCore} -->`, `<!-- @-- ${endCore} --@ -->`];
+  const start = starts.find((t) => html.includes(t));
+  const end = ends.find((t) => html.includes(t));
+  return { start, end };
+}
+
+function replaceBetween(html, start, end, content) {
+  const s = html.indexOf(start);
+  const e = html.indexOf(end);
+  if (s < 0 || e < 0 || e <= s) throw new Error(`Missing/invalid anchor pair: ${start} .. ${end}`);
+  return `${html.slice(0, s + start.length)}\n${content}\n${html.slice(e)}`;
+}
+
+export function detectTemplateProblems(html) {
+  const missing = [];
+  if (!/<script[^>]*id=["']dex-manifest["'][^>]*type=["']application\/json["']/i.test(html)) missing.push('script#dex-manifest[type="application/json"]');
+  if (!/window\.dexSidebarPageConfig\s*=/.test(html)) missing.push('a <script> containing window.dexSidebarPageConfig');
+  const hasVideo = /class=["'][^"']*sqs-video-wrapper/.test(html) || !!(markerTokens(html, 'video').start && markerTokens(html, 'video').end);
+  if (!hasVideo) missing.push('.sqs-video-wrapper or DEX video anchors');
+  return missing;
+}
+
+export function extractFormatKeys(html) {
+  const $ = load(html, { decodeEntities: false });
+  const txt = $('#dex-sidebar-config[type="application/json"]').first().text().trim();
+  if (!txt) return { audio: [], video: [] };
+  try {
+    const data = JSON.parse(txt);
+    return {
+      audio: (data.downloads?.formats?.audio || []).map((f) => f.key).filter(Boolean),
+      video: (data.downloads?.formats?.video || []).map((f) => f.key).filter(Boolean),
+    };
+  } catch {
+    return { audio: [], video: [] };
+  }
+}
+
+export function injectEntryHtml(templateHtml, { descriptionHtml, manifest, sidebarConfig, video, title, authEnabled = true }) {
+  let html = templateHtml;
+  let videoStrategy = 'selectors';
+  let descStrategy = 'selectors';
+  let sidebarStrategy = 'selectors';
+
+  const vm = markerTokens(html, 'video');
+  if (vm.start && vm.end) {
+    const start = html.indexOf(vm.start) + vm.start.length;
+    const end = html.indexOf(vm.end);
+    const region = html.slice(start, end);
+    const updated = region.replace(/(<div[^>]*class="[^"]*sqs-video-wrapper[^"]*"[^>]*)(>)/, (_, a, b) => {
+      const set = (tag, name, value) => {
+        const rx = new RegExp(`\\s${name}="[^"]*"`);
+        const v = String(value).replace(/&/g, '&amp;').replace(/"/g, '&quot;');
+        return rx.test(tag) ? tag.replace(rx, ` ${name}="${v}"`) : `${tag} ${name}="${v}"`;
+      };
+      let tag = a;
+      if (video.mode === 'url') {
+        tag = set(tag, 'data-url', video.dataUrl);
+        if (video.dataHtml) tag = set(tag, 'data-html', video.dataHtml);
+      } else {
+        tag = set(tag, 'data-url', '');
+        tag = set(tag, 'data-html', video.dataHtml);
+      }
+      return `${tag}${b}`;
+    });
+    html = replaceBetween(html, vm.start, vm.end, updated.trim());
+    videoStrategy = 'anchors';
+  } else {
+    const $ = load(html, { decodeEntities: false });
+    const node = $('.sqs-block.video-block .sqs-video-wrapper').first();
+    if (!node.length) throw new Error('Video target missing; add DEX video anchors or .sqs-video-wrapper');
+    if (video.mode === 'url') {
+      node.attr('data-url', video.dataUrl);
+      if (video.dataHtml) node.attr('data-html', video.dataHtml);
+    } else {
+      node.attr('data-url', '');
+      node.attr('data-html', video.dataHtml);
+    }
+    html = $.html();
+  }
+
+  const dm = markerTokens(html, 'desc');
+  if (dm.start && dm.end) {
+    html = replaceBetween(html, dm.start, dm.end, descriptionHtml.trim());
+    descStrategy = 'anchors';
+  } else {
+    throw new Error('Description anchors missing and selector fallback is ambiguous; add DEX:DESC anchors to template');
+  }
+
+  const sidebarJs = `window.dexSidebarPageConfig = ${JSON.stringify(sidebarConfig, null, 2)};`;
+  const sm = markerTokens(html, 'sidebar');
+  if (sm.start && sm.end) {
+    const start = html.indexOf(sm.start) + sm.start.length;
+    const end = html.indexOf(sm.end);
+    const region = html.slice(start, end);
+    const replaced = region.replace(/window\.dexSidebarPageConfig\s*=\s*[\s\S]*?;\s*/m, `${sidebarJs}\n`);
+    if (replaced === region) throw new Error('Sidebar anchor region found but window.dexSidebarPageConfig assignment missing');
+    html = replaceBetween(html, sm.start, sm.end, replaced.trim());
+    sidebarStrategy = 'anchors';
+  } else {
+    html = html.replace(/window\.dexSidebarPageConfig\s*=\s*[\s\S]*?;\s*/m, `${sidebarJs}\n`);
+    if (!html.includes(sidebarJs)) throw new Error('Sidebar config target missing; add DEX sidebar anchors');
+  }
+
+  html = html.replace(/(<script[^>]*id="dex-manifest"[^>]*type="application\/json"[^>]*>)([\s\S]*?)(<\/script>)/i, `$1\n${JSON.stringify(manifest, null, 2)}\n$3`);
+  if (!/"audio"\s*:/.test(html)) throw new Error('Failed to update dex-manifest JSON');
+  if (title) html = html.replace(/<title>[\s\S]*?<\/title>/i, `<title>${title}</title>`);
+
+  if (authEnabled) {
+    const canonical = AUTH_CANDIDATES.find((s) => html.includes(`src="${s}"`)) || AUTH_CANDIDATES[0];
+    html = html
+      .replace(/<!-- Auth0 -->[\s\S]*?<!-- end Auth0 -->/g, '')
+      .replace(/<[^>]*id="btn-login"[\s\S]*?<\/[^>]+>/g, '')
+      .replace(/<[^>]*id="btn-profile-container"[\s\S]*?<\/[^>]+>/g, '')
+      .replace(new RegExp(`<script[^>]*src="${esc(canonical)}"[^>]*><\\/script>\\s*`, 'g'), '')
+      .replace(new RegExp(`<script[^>]*src="${esc(AUTH_CDN)}"[^>]*><\\/script>\\s*`, 'g'), '')
+      .replace(/<script[^>]*src="\/assets\/dex-auth\.js"[^>]*><\/script>\s*/g, '');
+    const trio = `<script defer src="${canonical}"></script>\n<script defer src="${AUTH_CDN}"></script>\n<script defer src="/assets/dex-auth.js"></script>`;
+    if (!html.includes('</head>')) throw new Error('Cannot inject auth snippets: </head> not found');
+    html = html.replace('</head>', `${trio}\n</head>`);
+  }
+
+  return { html, strategy: { video: videoStrategy, description: descStrategy, sidebar: sidebarStrategy } };
+}
+
+export const AUTH_TRIO = [...AUTH_CANDIDATES, AUTH_CDN, '/assets/dex-auth.js'];

--- a/scripts/lib/entry-schema.mjs
+++ b/scripts/lib/entry-schema.mjs
@@ -1,0 +1,52 @@
+import { z } from 'zod';
+
+export const BUCKETS = ['A', 'B', 'C', 'D', 'E', 'X'];
+
+const linkSchema = z.object({ label: z.string().min(1), href: z.string().min(1) });
+const personSchema = z.object({ name: z.string().default(''), links: z.array(linkSchema).default([]) });
+
+export const sidebarConfigSchema = z.object({
+  lookupNumber: z.string().min(1),
+  buckets: z.array(z.enum(BUCKETS)).min(1),
+  specialEventImage: z.string().nullable().optional(),
+  attributionSentence: z.string().min(1),
+  credits: z.object({
+    artist: personSchema,
+    artistAlt: z.string().nullable().optional(),
+    instruments: z.array(personSchema).default([]),
+    video: z.object({ director: personSchema, cinematography: personSchema, editing: personSchema }),
+    audio: z.object({ recording: personSchema, mix: personSchema, master: personSchema }),
+    year: z.number().int(),
+    season: z.string().min(1),
+    location: z.string().min(1),
+  }),
+  fileSpecs: z.object({
+    bitDepth: z.number().int().default(24),
+    sampleRate: z.number().int().default(48000),
+    channels: z.enum(['mono', 'stereo', 'multichannel']).default('stereo'),
+    staticSizes: z.object({ A: z.string().default(''), B: z.string().default(''), C: z.string().default(''), D: z.string().default(''), E: z.string().default(''), X: z.string().default('') }),
+  }),
+  metadata: z.object({ sampleLength: z.string().default(''), tags: z.array(z.string()).default([]) }),
+});
+
+export const entrySchema = z.object({
+  slug: z.string().min(1),
+  title: z.string().min(1),
+  video: z.object({ mode: z.enum(['url', 'embed']), dataUrl: z.string().default(''), dataHtml: z.string().default('') }),
+  sidebarPageConfig: sidebarConfigSchema,
+});
+
+export function manifestSchemaForFormats(audioKeys = [], videoKeys = []) {
+  const recordFor = (keys) => (keys.length
+    ? z.object(Object.fromEntries(keys.map((k) => [k, z.string().default('')]))).passthrough()
+    : z.record(z.string(), z.string().default('')));
+  return z.object({ audio: z.record(recordFor(audioKeys)).default({}), video: z.record(recordFor(videoKeys)).default({}) });
+}
+
+export function slugify(input) {
+  return String(input).toLowerCase().replace(/[\s_]+/g, '-').replace(/[^a-z0-9-]/g, '').replace(/-+/g, '-').replace(/^-|-$/g, '');
+}
+
+export function formatZodError(error, where) {
+  return `${where}: ${error.issues.map((i) => `${i.path.join('.') || '(root)'}: ${i.message}`).join('; ')}`;
+}

--- a/scripts/smoke-dex-init.mjs
+++ b/scripts/smoke-dex-init.mjs
@@ -1,0 +1,35 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const root = process.cwd();
+const temp = await fs.mkdtemp(path.join(os.tmpdir(), 'dex-smoke-'));
+const tmpl = `<!doctype html><html><head><title>Template</title><script defer src="/assets/dex-auth0-config.js"></script></head><body>
+<script id="dex-sidebar-config" type="application/json">{"downloads":{"formats":{"audio":[{"key":"wav"}],"video":[{"key":"1080p"}]}}}</script>
+<!-- DEX:SIDEBAR_PAGE_CONFIG_START --><script>window.dexSidebarPageConfig = {};</script><!-- DEX:SIDEBAR_PAGE_CONFIG_END -->
+<!-- DEX:VIDEO_START --><div class="sqs-block video-block"><div class="sqs-video-wrapper" data-url="" data-html=""></div></div><!-- DEX:VIDEO_END -->
+<!-- DEX:DESC_START --><p>lorem ipsum</p><!-- DEX:DESC_END -->
+<script id="dex-manifest" type="application/json">{}</script>
+</body></html>`;
+await fs.writeFile(path.join(temp, 'index.html'), tmpl, 'utf8');
+await fs.writeFile(path.join(temp, 'seed.json'), JSON.stringify({
+  title: 'Smoke Title',
+  slug: 'smoke-title',
+  descriptionHtml: '<p>desc</p>',
+  video: { dataUrl: 'https://player.vimeo.com/video/1' },
+  manifest: { audio: { A: { wav: 'a1' } }, video: { A: { '1080p': 'v1' } } },
+  sidebarPageConfig: { lookupNumber: 'LOOKUP-1', attributionSentence: 'attrib', buckets: ['A'], credits: { artist: { name: 'Artist' }, year: 2026, season: 'S2', location: 'Somewhere' } },
+}), 'utf8');
+
+const run = (args) => spawnSync('node', [path.join(root, 'scripts/dex.mjs'), ...args], { cwd: temp, encoding: 'utf8' });
+const dry = run(['init', '--quick', '--template', './index.html', '--out', './entries', '--dry-run', '--from', './seed.json']);
+if (dry.status !== 0) throw new Error(`dry-run failed: ${dry.stderr}\n${dry.stdout}`);
+const real = run(['init', '--quick', '--template', './index.html', '--out', './entries', '--from', './seed.json']);
+if (real.status !== 0) throw new Error(`write run failed: ${real.stderr}\n${real.stdout}`);
+
+const outHtml = await fs.readFile(path.join(temp, 'entries', 'smoke-title', 'index.html'), 'utf8');
+for (const needle of ['data-url="https://player.vimeo.com/video/1"', 'LOOKUP-1', '"wav": "a1"', '/assets/dex-auth0-config.js', '/assets/dex-auth.js']) {
+  if (!outHtml.includes(needle)) throw new Error(`missing in output html: ${needle}`);
+}
+console.log('smoke-dex-init ok');


### PR DESCRIPTION
### Motivation
- Provide a single, best-in-class `dex init` one-command wizard that scans the repo for the correct template, guides entry creation, and produces a new entry folder with minimal, deterministic edits to the page HTML. 
- Ensure safety and robustness by failing fast on ambiguous/missing injection targets, preserving unrelated HTML, and supporting Node 18+ ESM toolchain and industry-standard libs.

### Description
- Add a Commander-based CLI entrypoint at `scripts/dex.mjs` implementing `dex init [slug]` (flags: `--quick`, `--advanced`, `--out`, `--template`, `--open`, `--dry-run`, `--flat`, `--from`) plus a `validate` wrapper and legacy `build`/`watch` placeholders.  
- Introduce deterministic HTML injection helpers in `scripts/lib/entry-html.mjs` that use anchors-first region replacement (`DEX:VIDEO_START/END`, `DEX:DESC_START/END`, `DEX:SIDEBAR_PAGE_CONFIG_START/END`) with selector fallbacks, manifest/script updates, and canonical auth snippet normalization while avoiding broad reformatting.  
- Add `scripts/lib/entry-schema.mjs` with Zod schemas and utilities (`slugify`, manifest schema factory) used to validate sidebar, manifest and entry data, and added non-interactive seeding support for CI/dry-run flows.  
- Add a smoke test `scripts/smoke-dex-init.mjs`, update `package.json` to expose `dex` via `bin`, add `prompts` dependency and `npm` scripts (`dex`, `smoke:dex-init`), and update `README.md` with quick-start notes; output files written by `init` are `index.html`, `entry.json`, `description.html`, and `manifest.json` under the chosen `--out` folder.

### Testing
- Ran `node scripts/dex.mjs --help` to confirm CLI shape, which returned expected commands and options (success).  
- Executed the smoke flow `npm run smoke:dex-init` which performs a dry-run and a real init from a fixture template and asserts injected markers (video `data-url`/`data-html`, `LOOKUP` number, manifest keys, and auth snippet presence), and it completed successfully.  
- Performed `npm i` during the rollout to ensure dependencies (`prompts`) installed and the smoke script ran in the prepared environment (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69984321f85c832785872046de4851e6)