### PR TITLE
Fix Ink dashboard UX and init launch handoff

### DIFF
--- a/scripts/dex.mjs
+++ b/scripts/dex.mjs
@@ -326,17 +326,28 @@ if (topLevel.mode === 'dashboard') {
   });
 
   if (action === 'init') {
-    await initCommand(undefined, {
-      out: './entries',
-      quick: false,
-      advanced: false,
-      template: undefined,
-      open: false,
-      dryRun: false,
-      flat: false,
-      from: undefined,
+    process.stdout.write('\x1b[?25h');
+    process.stdout.write('\x1b[0m');
+    process.stdout.write('\x1b[2J\x1b[H');
+
+    const child = spawn(process.execPath, [path.join(SCRIPT_DIR, 'dex.mjs'), 'init'], {
+      stdio: 'inherit',
     });
+
+    const exitCode = await new Promise((resolve, reject) => {
+      child.once('error', reject);
+      child.once('exit', (code, signal) => {
+        if (signal) {
+          resolve(1);
+          return;
+        }
+        resolve(code ?? 0);
+      });
+    });
+
+    process.exit(exitCode);
   }
+
   process.exit(0);
 }
 

--- a/scripts/ui/dashboard.mjs
+++ b/scripts/ui/dashboard.mjs
@@ -166,18 +166,31 @@ function DashboardApp({ initialPaletteOpen, version, onResolve, noAnim }) {
     { flexDirection: 'column', width: cols, height: rows },
     React.createElement(
       Box,
-      { flexDirection: 'column', paddingX: 2, paddingTop: 1 },
-      ...logoLines.map((line, i) => React.createElement(Text, { key: `logo-${i}` }, line)),
-      React.createElement(Text, { color: '#6e7688' }, `v${version}`),
-      React.createElement(Text, {}, divider),
+      { flexDirection: 'column', paddingX: 2, paddingTop: 1, width: '100%' },
+      React.createElement(
+        Box,
+        { width: '100%', justifyContent: 'center' },
+        React.createElement(
+          Box,
+          { flexDirection: 'column', alignItems: 'center' },
+          ...logoLines.map((line, i) => React.createElement(Text, { key: `logo-${i}` }, line)),
+          React.createElement(Text, { color: '#6e7688' }, `v${version}`),
+        ),
+      ),
+      React.createElement(
+        Box,
+        { width: '100%', justifyContent: 'center' },
+        React.createElement(Text, {}, divider),
+      ),
     ),
     React.createElement(Box, { flexGrow: 1 }),
     React.createElement(
       Box,
       { flexDirection: 'column', alignItems: 'center' },
-      MENU_ITEMS.map((item, idx) => React.createElement(
+      React.createElement(Text, { color: '#6e7688', dimColor: true }, 'Commands'),
+      ...MENU_ITEMS.map((item, idx) => React.createElement(
         Box,
-        { key: item, marginBottom: 1 },
+        { key: item, height: 1 },
         React.createElement(Text, idx === selected ? { inverse: true } : { color: '#d0d5df' }, item),
       )),
     ),


### PR DESCRIPTION
### Motivation

- Improve dashboard visual stability so menu selection does not shift layout and header is centered for a contained TUI experience.
- Ensure launching the `init` wizard from the dashboard does not trigger unsettled top-level await warnings or append prompts to the dashboard hints line.
- Preserve existing `dex init` wizard behavior and keep the dashboard Ink-based with palette overlay behavior intact.

### Description

- Centered the header/logo + version by wrapping them in full-width centered `<Box>` containers and rendering multi-line logo lines in a centered column in `scripts/ui/dashboard.mjs`.
- Added a dim `Commands` heading above the command list and constrained menu rows to `height: 1` so selection highlighting does not add or remove lines, preventing layout shifts, and kept the palette as an absolute overlay so it does not reflow the base layout.
- Replaced the dashboard-internal call to `initCommand(...)` with a handoff: after `runDashboard()` returns `{ action }`, the dashboard path in `scripts/dex.mjs` now clears/restores terminal state (`\x1b[?25h`, `\x1b[0m`, `\x1b[2J\x1b[H`), spawns a child using `process.execPath` and `scripts/dex.mjs init` with `stdio: 'inherit'`, awaits the child exit code, and exits with the same code.
- Removed any direct `await initCommand(...)` invocation from the dashboard code path so the init wizard runs outside the Ink app lifecycle.

### Testing

- Ran `node --check scripts/ui/dashboard.mjs` and it succeeded.
- Ran `node --check scripts/dex.mjs` and it succeeded.
- Ran `node scripts/dex.mjs init --help` and it produced the expected `dex init` usage output (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998d54cb2b483278f9573c493a507aa)