### PR TITLE
Fix Ink init wizard key handling and input focus ownership

### DIFF
--- a/scripts/smoke-dex-init.mjs
+++ b/scripts/smoke-dex-init.mjs
@@ -106,4 +106,35 @@ if (isBackspaceKey('\x08', {}) !== true) throw new Error('backspace helper shoul
   if (next.value !== 'abc' || next.cursor !== 1) throw new Error('escape sequence should be ignored');
 }
 
+
+{
+  const next = applyKeyToInputState({ value: 'abc', cursor: 2 }, '', { leftArrow: true });
+  if (next.value !== 'abc' || next.cursor !== 1) throw new Error('left arrow should move cursor left');
+}
+
+{
+  const next = applyKeyToInputState({ value: 'abc', cursor: 1 }, '', { rightArrow: true });
+  if (next.value !== 'abc' || next.cursor !== 2) throw new Error('right arrow should move cursor right');
+}
+
+{
+  const next = applyKeyToInputState({ value: 'abc', cursor: 2 }, '', { home: true });
+  if (next.value !== 'abc' || next.cursor !== 0) throw new Error('home should move cursor to start');
+}
+
+{
+  const next = applyKeyToInputState({ value: 'abc', cursor: 1 }, '', { end: true });
+  if (next.value !== 'abc' || next.cursor !== 3) throw new Error('end should move cursor to end');
+}
+
+{
+  const next = applyKeyToInputState({ value: 'abc', cursor: 2 }, '[D', { leftArrow: false });
+  if (next.value !== 'abc' || next.cursor !== 1) throw new Error('left escape sequence should move cursor left');
+}
+
+{
+  const next = applyKeyToInputState({ value: 'abc', cursor: 1 }, '[3~', {});
+  if (next.value !== 'ac' || next.cursor !== 1) throw new Error('delete escape sequence should remove char at cursor');
+}
+
 console.log('smoke-dex-init ok');

--- a/scripts/ui/dashboard.mjs
+++ b/scripts/ui/dashboard.mjs
@@ -113,7 +113,7 @@ function DashboardApp({ initialPaletteOpen, version, noAnim }) {
     if (key.upArrow) { setSelected((idx) => (idx - 1 + MENU_ITEMS.length) % MENU_ITEMS.length); return; }
     if (key.downArrow) { setSelected((idx) => (idx + 1) % MENU_ITEMS.length); return; }
     if (key.return && MENU_ITEMS[selected]?.id === 'init') setMode('init');
-  });
+  }, { isActive: mode === 'menu' || mode === 'palette' });
 
   const paletteWidth = Math.min(72, Math.max(24, cols - 4));
   const paletteHeight = Math.min(14, Math.max(8, rows - 4));

--- a/scripts/ui/init-wizard.mjs
+++ b/scripts/ui/init-wizard.mjs
@@ -57,24 +57,32 @@ function withCaret(value, cursor, caretOn) {
 }
 
 function looksLikeEscapeSequence(input) {
-  return typeof input === 'string' && input.startsWith('\x1b');
+  return typeof input === 'string' && input.includes('\x1b');
 }
 
 export function applyKeyToInputState(state, input, key = {}) {
   const value = state?.value ?? '';
   const cursor = Math.max(0, Math.min(value.length, state?.cursor ?? 0));
 
-  if (key.leftArrow) return { value, cursor: Math.max(0, cursor - 1) };
-  if (key.rightArrow) return { value, cursor: Math.min(value.length, cursor + 1) };
-  if (key.home) return { value, cursor: 0 };
-  if (key.end) return { value, cursor: value.length };
+  if (key.ctrl && (input === 'q' || input === 'Q')) return { value, cursor, quit: true };
+
+  const isLeft = !!(key.leftArrow || input === '\x1b[D');
+  const isRight = !!(key.rightArrow || input === '\x1b[C');
+  const isHome = !!(key.home || input === '\x1b[H' || input === '\x1bOH');
+  const isEnd = !!(key.end || input === '\x1b[F' || input === '\x1bOF');
+  const isDelete = !!(key.delete || (typeof input === 'string' && /^\x1b\[3(?:;\d+)*~$/.test(input)));
+
+  if (isLeft) return { value, cursor: Math.max(0, cursor - 1) };
+  if (isRight) return { value, cursor: Math.min(value.length, cursor + 1) };
+  if (isHome) return { value, cursor: 0 };
+  if (isEnd) return { value, cursor: value.length };
 
   if (isBackspaceKey(input, key)) {
     if (cursor === 0) return { value, cursor };
     return { value: `${value.slice(0, cursor - 1)}${value.slice(cursor)}`, cursor: cursor - 1 };
   }
 
-  if (key.delete) {
+  if (isDelete) {
     if (cursor >= value.length) return { value, cursor };
     return { value: `${value.slice(0, cursor)}${value.slice(cursor + 1)}`, cursor };
   }
@@ -84,7 +92,7 @@ export function applyKeyToInputState(state, input, key = {}) {
   if (shouldAppendWizardChar(input, key)) {
     return {
       value: `${value.slice(0, cursor)}${input}${value.slice(cursor)}`,
-      cursor: cursor + input.length,
+      cursor: cursor + 1,
     };
   }
 
@@ -116,6 +124,7 @@ export function InitWizard({ templateArg, outDirDefault, onCancel, onDone }) {
   const [statusLines, setStatusLines] = useState([]);
   const [doneReport, setDoneReport] = useState(null);
   const [multiCursor, setMultiCursor] = useState(0);
+  const [lastKeyEvent, setLastKeyEvent] = useState(null);
   const templateRef = useRef(null);
   const [form, setForm] = useState({
     title: '',
@@ -265,11 +274,26 @@ export function InitWizard({ templateArg, outDirDefault, onCancel, onDone }) {
   };
 
   useInput((input, key) => {
-    if (busy) return;
-    if (key.ctrl && (input === 'q' || input === 'Q')) {
-      onCancel();
-      return;
+    if (process.env.DEX_KEY_DEBUG === '1') {
+      setLastKeyEvent({
+        input,
+        flags: {
+          backspace: !!key.backspace,
+          delete: !!key.delete,
+          leftArrow: !!key.leftArrow,
+          rightArrow: !!key.rightArrow,
+          upArrow: !!key.upArrow,
+          downArrow: !!key.downArrow,
+          return: !!key.return,
+          escape: !!key.escape,
+          ctrl: !!key.ctrl,
+          meta: !!key.meta,
+          shift: !!key.shift,
+        },
+      });
     }
+
+    if (busy) return;
     if (doneReport) {
       if (key.return) onDone(doneReport);
       return;
@@ -282,6 +306,7 @@ export function InitWizard({ templateArg, outDirDefault, onCancel, onDone }) {
     }
 
     if (step.kind === 'multi') {
+      if (key.ctrl && (input === 'q' || input === 'Q')) { onCancel(); return; }
       if (key.upArrow) { setMultiCursor((prev) => (prev - 1 + BUCKETS.length) % BUCKETS.length); return; }
       if (key.downArrow) { setMultiCursor((prev) => (prev + 1) % BUCKETS.length); return; }
       if (input === ' ') {
@@ -298,25 +323,29 @@ export function InitWizard({ templateArg, outDirDefault, onCancel, onDone }) {
     }
 
     if (step.kind === 'stub') {
+      if (key.ctrl && (input === 'q' || input === 'Q')) { onCancel(); return; }
       if (key.return) void maybeAdvance();
       return;
     }
 
     if (step.kind === 'summary') {
+      if (key.ctrl && (input === 'q' || input === 'Q')) { onCancel(); return; }
       if (key.return) void maybeAdvance();
       return;
     }
 
-    if (key.leftArrow || key.rightArrow || key.home || key.end || isBackspaceKey(input, key) || key.delete || looksLikeEscapeSequence(input) || shouldAppendWizardChar(input, key)) {
+    if (step.kind === 'text') {
+      const next = applyKeyToInputState({ value: form[step.id] ?? '', cursor: cursorByStep[step.id] ?? 0 }, input, key);
+      if (next.quit) {
+        onCancel();
+        return;
+      }
       applyTextEdit(input, key);
+      if (key.return) void maybeAdvance();
       return;
     }
 
-    if (key.return) {
-      void maybeAdvance();
-      return;
-    }
-
+    if (key.return) void maybeAdvance();
   });
 
   return React.createElement(Box, { flexDirection: 'column', height: '100%' },
@@ -345,6 +374,12 @@ export function InitWizard({ templateArg, outDirDefault, onCancel, onDone }) {
     busy ? React.createElement(Text, { color: '#ffcc66' }, 'Generating...') : null,
     error ? React.createElement(Text, { color: '#ff6b6b' }, error) : null,
     ...(doneReport ? statusLines.map((line, i) => React.createElement(Text, { key: `ok-${i}`, color: '#a6e3a1' }, line)) : []),
+    (process.env.DEX_KEY_DEBUG === '1')
+      ? React.createElement(Box, { marginTop: 1, borderStyle: 'single', borderColor: '#5f6a7d', paddingX: 1, flexDirection: 'column' },
+        React.createElement(Text, { color: '#8f98a8' }, 'Key debug'),
+        React.createElement(Text, { color: '#d0d5df' }, `input: ${JSON.stringify(lastKeyEvent?.input ?? null)}`),
+        React.createElement(Text, { color: '#d0d5df' }, `flags: ${JSON.stringify(lastKeyEvent?.flags ?? {})}`),
+      ) : null,
     React.createElement(Box, { marginTop: 1 }, React.createElement(Text, { color: '#6e7688' }, footer)),
   );
 }


### PR DESCRIPTION
### Motivation
- The dashboard-level input handler was intercepting keystrokes while the Init wizard was active, preventing Backspace/Arrow/Home/End/Delete from reaching the wizard.
- The wizard previously allowed some direct appends and could receive raw escape sequences; a single guarded reducer was needed to centralize editing semantics and reject escape sequences.
- A temporary, gated in-UI debug overlay was requested to observe raw `input` and key flags to diagnose which layer receives events.

### Description
- Deactivate dashboard input when the wizard is visible by using Ink's `useInput(..., { isActive })` so `DashboardApp` only handles keys in `menu`/`palette` modes (`scripts/ui/dashboard.mjs`).
- Harden the wizard text-edit reducer `applyKeyToInputState` to add `ctrl+q` quit signaling, recognize arrows/home/end/delete via Ink flags and escape-sequence fallbacks, reject unmatched escape sequences, and insert only single printable characters (`scripts/ui/init-wizard.mjs`).
- Route all text-step edits through the reducer in the wizard `useInput` handler and ensure Enter advances as before (`scripts/ui/init-wizard.mjs`).
- Add a gated debug overlay displayed inside the wizard when `DEX_KEY_DEBUG=1` that shows the last `input` and a JSON object of the key flags (backspace, delete, arrows, return, escape, ctrl, meta, shift) (`scripts/ui/init-wizard.mjs`).
- Extend the smoke test script with reducer assertions for left/right/home/end movement, delete escape-sequence fallback, and escape-sequence rejection to prevent regressions (`scripts/smoke-dex-init.mjs`).

### Testing
- Ran the automated smoke script `npm run smoke:dex-init`, which passed and printed `smoke-dex-init ok` after the new assertions succeeded.
- The smoke script now includes assertions covering backspace, delete, insert, arrow/home/end movement, escape-sequence ignoring, and delete escape-sequence handling.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998f7b18a6c83278f322df3645b9e58)