### PR TITLE
Fix wizard reducer wiring so backspace/arrows apply reliably

### DIFF
--- a/scripts/smoke-dex-init.mjs
+++ b/scripts/smoke-dex-init.mjs
@@ -106,4 +106,41 @@ if (isBackspaceKey('\x08', {}) !== true) throw new Error('backspace helper shoul
   if (next.value !== 'abc' || next.cursor !== 1) throw new Error('escape sequence should be ignored');
 }
 
+
+{
+  const next = applyKeyToInputState({ value: 'abc', cursor: 2 }, '', { leftArrow: true });
+  if (next.value !== 'abc' || next.cursor !== 1) throw new Error('left arrow should move cursor left');
+}
+
+{
+  const next = applyKeyToInputState({ value: 'abc', cursor: 1 }, '', { rightArrow: true });
+  if (next.value !== 'abc' || next.cursor !== 2) throw new Error('right arrow should move cursor right');
+}
+
+{
+  const next = applyKeyToInputState({ value: 'abc', cursor: 2 }, '', { home: true });
+  if (next.value !== 'abc' || next.cursor !== 0) throw new Error('home should move cursor to start');
+}
+
+{
+  const next = applyKeyToInputState({ value: 'abc', cursor: 1 }, '', { end: true });
+  if (next.value !== 'abc' || next.cursor !== 3) throw new Error('end should move cursor to end');
+}
+
+{
+  const next = applyKeyToInputState({ value: 'abc', cursor: 2 }, '[D', { leftArrow: false });
+  if (next.value !== 'abc' || next.cursor !== 1) throw new Error('left escape sequence should move cursor left');
+}
+
+
+{
+  const next = applyKeyToInputState({ value: 'abc', cursor: 2 }, 'OD', { leftArrow: false });
+  if (next.value !== 'abc' || next.cursor !== 1) throw new Error('left SS3 sequence should move cursor left');
+}
+
+{
+  const next = applyKeyToInputState({ value: 'abc', cursor: 1 }, '[3~', {});
+  if (next.value !== 'ac' || next.cursor !== 1) throw new Error('delete escape sequence should remove char at cursor');
+}
+
 console.log('smoke-dex-init ok');

--- a/scripts/ui/dashboard.mjs
+++ b/scripts/ui/dashboard.mjs
@@ -113,7 +113,7 @@ function DashboardApp({ initialPaletteOpen, version, noAnim }) {
     if (key.upArrow) { setSelected((idx) => (idx - 1 + MENU_ITEMS.length) % MENU_ITEMS.length); return; }
     if (key.downArrow) { setSelected((idx) => (idx + 1) % MENU_ITEMS.length); return; }
     if (key.return && MENU_ITEMS[selected]?.id === 'init') setMode('init');
-  });
+  }, { isActive: mode === 'menu' || mode === 'palette' });
 
   const paletteWidth = Math.min(72, Math.max(24, cols - 4));
   const paletteHeight = Math.min(14, Math.max(8, rows - 4));


### PR DESCRIPTION
### Motivation
- Input events in the Init wizard were being observed but not consistently applied to wizard state, causing Backspace/arrow/home/end/delete to appear to do nothing in some terminals.
- Some terminals emit SS3-style arrow sequences (`\x1bOD`/`\x1bOC`) or escape variants that were not being handled, so arrow movement could be lost when Ink key flags are missing.
- Improve diagnosability for tricky terminal key behavior by surfacing the last key event when debugging is enabled.

### Description
- Route all text-step edits through the mutating helper `applyTextEdit()` and use its returned result for quit signaling so reducer outputs are actually applied to form and cursor state (`scripts/ui/init-wizard.mjs`).
- Harden `applyKeyToInputState` to recognize SS3 left/right arrow fallbacks (`\x1bOD` / `\x1bOC`), add home/end fallbacks, detect delete via a regex for `\x1b[3~` style sequences, and avoid inserting multi-character escape sequences as text (`scripts/ui/init-wizard.mjs`).
- Make `looksLikeEscapeSequence` more robust by checking for the escape byte anywhere in the input so stray sequences are ignored (`scripts/ui/init-wizard.mjs`).
- Add an optional in-UI key debug display that shows the last `input` and parsed key flags when `DEX_KEY_DEBUG=1` (`scripts/ui/init-wizard.mjs`).
- Ensure the dashboard-level input handler is only active when in `menu`/`palette` modes by passing the Ink `isActive` option so the dashboard won't intercept keys while the wizard is visible (`scripts/ui/dashboard.mjs`).
- Add smoke coverage for SS3 left-arrow sequence and other cursor/edit operations to prevent regressions (`scripts/smoke-dex-init.mjs`).

### Testing
- Ran the automated smoke script `npm run smoke:dex-init`, which passed (`smoke-dex-init ok`).
- The new smoke assertions include backspace, delete, insert, arrow/home/end movement, ignore-escape-sequence behavior, and SS3 left-arrow fallback, and they all succeeded in the CI-like smoke run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998f7b18a6c83278f322df3645b9e58)