### PR TITLE
Fix init wizard backspace crash and improve escape-sequence key handling

### DIFF
--- a/scripts/smoke-dex-init.mjs
+++ b/scripts/smoke-dex-init.mjs
@@ -143,4 +143,23 @@ if (isBackspaceKey('\x08', {}) !== true) throw new Error('backspace helper shoul
   if (next.value !== 'ac' || next.cursor !== 1) throw new Error('delete escape sequence should remove char at cursor');
 }
 
+
+{
+  const next = applyKeyToInputState({ value: 'abc', cursor: 1 }, '\x1b[1~', {});
+  if (!next || typeof next !== 'object') throw new Error('reducer should always return an object');
+  if (next.value !== 'abc' || next.cursor !== 0) throw new Error('home [1~ should move cursor to start');
+}
+
+{
+  const next = applyKeyToInputState({ value: 'abc', cursor: 0 }, '\x1b[4~', {});
+  if (!next || typeof next !== 'object') throw new Error('reducer should always return an object');
+  if (next.value !== 'abc' || next.cursor !== 3) throw new Error('end [4~ should move cursor to end');
+}
+
+{
+  const next = applyKeyToInputState({ value: 'abc', cursor: 1 }, '\x1b[3~', {});
+  if (!next || typeof next !== 'object') throw new Error('reducer should always return an object');
+  if (next.value !== 'ac' || next.cursor !== 1) throw new Error('delete [3~ should remove char at cursor');
+}
+
 console.log('smoke-dex-init ok');


### PR DESCRIPTION
### Motivation
- The init wizard could crash when `applyTextEdit()` early-returned `undefined`, and callers read `next.quit` unguarded. 
- Key handling relied solely on Ink flags and missed many common terminal escape sequences, causing navigation and delete/backspace to be unreliable. 
- We need to ensure the dashboard does not intercept wizard input and add minimal key debug info to observe what the terminal is sending.

### Description
- Ensure `applyTextEdit()` always returns a result object (`{ value, cursor, quit? }`) while only updating React state when the value or cursor actually change, and make the caller defensive with `next?.quit` (files: `scripts/ui/init-wizard.mjs`).
- Extend `applyKeyToInputState()` to recognize additional Home/End variants (`\x1b[1~`, `\x1b[7~`, `\x1b[4~`, `\x1b[8~`) and maintain existing arrow/delete/backspace handling and suppression of arbitrary escape-containing input so escape bytes are never inserted into the text field (file: `scripts/ui/init-wizard.mjs`).
- Add `inputLen` and `hasEscape` diagnostic fields to the `DEX_KEY_DEBUG=1` overlay so key transport can be inspected per keypress (file: `scripts/ui/init-wizard.mjs`).
- Verify dashboard input handling is gated to not run while the wizard is active (no change required to other files beyond verification). 
- Add smoke checks asserting the reducer always returns an object and that Home/End/Delete escape-sequence variants behave as expected (file: `scripts/smoke-dex-init.mjs`).

### Testing
- Ran the extended smoke script `node scripts/smoke-dex-init.mjs` and it completed successfully.
- Unit-like assertions in `scripts/smoke-dex-init.mjs` validate backspace/delete/left/right/home/end escape-sequence behavior and that the reducer never returns `undefined` (all passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699909ba86708327b765eb507d936426)