### PR TITLE
Fix init wizard buckets state and defensive validation

### DIFF
--- a/scripts/test-init-wizard-validate.mjs
+++ b/scripts/test-init-wizard-validate.mjs
@@ -1,0 +1,19 @@
+import { createDefaultWizardForm, validateStep } from './ui/init-wizard.mjs';
+
+const base = createDefaultWizardForm();
+const emptyBucketsError = validateStep('buckets', { ...base, buckets: [] });
+if (emptyBucketsError !== 'Select at least one bucket.') {
+  throw new Error(`expected buckets validation error, got: ${String(emptyBucketsError)}`);
+}
+
+const missingBucketsError = validateStep('buckets', { ...base, buckets: undefined });
+if (missingBucketsError !== 'Select at least one bucket.') {
+  throw new Error(`expected defensive buckets validation error, got: ${String(missingBucketsError)}`);
+}
+
+const ok = validateStep('buckets', { ...base, buckets: ['A'] });
+if (ok != null) {
+  throw new Error(`expected no buckets validation error, got: ${String(ok)}`);
+}
+
+console.log('test-init-wizard-validate ok');


### PR DESCRIPTION
### Motivation
- Prevent runtime crash when the Buckets step reads `form.buckets` when it is undefined and ensure the wizard uses a single canonical bucket field. 
- Make validation defensive so missing fields do not throw and instead surface inline errors. 
- Keep behavior identical for dashboard output and avoid regressions in the Ink dashboard shell. 

### Description
- Add `createDefaultWizardForm()` and initialize wizard state with it so `form.buckets` is always an array by default. 
- Normalize the wizard to use `form.buckets` everywhere (Buckets UI toggles, download row generation, paste parsing, summary and output serialization) instead of `selectedBuckets`. 
- Harden `validateStep` to defensively handle missing/invalid fields (treat missing buckets as `[]`, guard credits/download metadata) and return an error string or `null` rather than throwing. 
- Add a minimal non-interactive regression script `scripts/test-init-wizard-validate.mjs` that asserts buckets validation for empty, missing, and populated buckets. 

### Testing
- Ran the unit-ish validation script: `node scripts/test-init-wizard-validate.mjs` which completed successfully. 
- Ran the existing smoke test: `npm run -s smoke:dex-init` which completed successfully. 
- Manual verification checklist included for runtime checks: advancing Buckets step, inline error blocking when empty, successful advance when selecting `A`, and `Ctrl+Q` exit behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699914ca3c9083279cc10394f7e1f41c)