### PR TITLE
Fix Credits input UX and validation in init wizard

### DIFF
--- a/scripts/test-init-wizard-validate.mjs
+++ b/scripts/test-init-wizard-validate.mjs
@@ -16,4 +16,27 @@ if (ok != null) {
   throw new Error(`expected no buckets validation error, got: ${String(ok)}`);
 }
 
+const defaultCreditsError = validateStep('credits', base);
+if (defaultCreditsError !== 'Artist(s) needs at least one name.') {
+  throw new Error(`expected default credits validation error, got: ${String(defaultCreditsError)}`);
+}
+
+const populatedCredits = {
+  ...base,
+  creditsData: {
+    ...base.creditsData,
+    artist: ['A'],
+    instruments: ['B'],
+    video: { director: ['C'], cinematography: ['D'], editing: ['E'] },
+    audio: { recording: ['F'], mix: ['G'], master: ['H'] },
+    year: '2024',
+    season: 'S1',
+    location: 'Somewhere',
+  },
+};
+const creditsOk = validateStep('credits', populatedCredits);
+if (creditsOk != null) {
+  throw new Error(`expected no credits validation error, got: ${String(creditsOk)}`);
+}
+
 console.log('test-init-wizard-validate ok');


### PR DESCRIPTION
### Motivation
- Restore expected Credits-step behavior in the init wizard by making text input obvious and editable, avoiding accidental command collisions with normal typing, and fixing required-field gating that prevented advancing.
- Prevent escape-like terminal sequences from being inserted into free-text fields (e.g. `[27;5;13~`).

### Description
- Harden input filtering by adding `looksLikeBracketTildeSequence()` and ignoring bracket-tilde style sequences, and accept `\x11` as an alternate Ctrl+Q quit signal in `applyKeyToInputState` in `scripts/ui/init-wizard.mjs`.
- Rework Credits step to use a cursor-aware `creditsInputState = { value, cursor }`, add scalar rows (`year`, `season`, `location`, `artistAlt`) to `creditRoles`, and sync the input buffer when the selected role changes so scalar fields are editable live.
- Change list-role commands to Ctrl-mod combos (Ctrl+A / `\x01` to add comma-separated names, Ctrl+D to remove last) and ensure plain letters are treated as text input; update Credits UI to show `› Editing: <Role>` and an input box rendered with `withCaret()`.
- Validate credits globally in `validateStep('credits', ...)` by checking all required list roles (artist, instruments, video.* and audio.*) have at least one name, then validate `year`, `season`, and `location`.
- Update UI hint/footer text to reflect the new controls and add minimal test coverage changes in `scripts/test-init-wizard-validate.mjs` to assert default-fail and populated-pass credits validation.

### Testing
- Ran `node scripts/test-init-wizard-validate.mjs`; the test completed successfully.
- Performed static checks with `node --check scripts/ui/init-wizard.mjs` and `node --check scripts/test-init-wizard-validate.mjs`; both checks succeeded.
- Verified the updated validation/test scenarios where default form fails credits and a minimally populated `creditsData` passes via the added assertions in `scripts/test-init-wizard-validate.mjs`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699917a103fc83278fe7fbab8ce724db)