### PR TITLE
Improve init wizard download UX, tags picker, and rolodex scrolling

### DIFF
--- a/scripts/data/tags.txt
+++ b/scripts/data/tags.txt
@@ -1,0 +1,10 @@
+live
+studio
+acoustic
+electronic
+instrumental
+vocal
+ambient
+cinematic
+experimental
+improv

--- a/scripts/ui/rolodex.mjs
+++ b/scripts/ui/rolodex.mjs
@@ -1,0 +1,18 @@
+export function computeWindow({ total, cursor, height, pad = 1 }) {
+  const safeTotal = Math.max(0, Number(total) || 0);
+  const safeHeight = Math.max(1, Number(height) || 1);
+  if (safeTotal <= safeHeight) return { start: 0, end: safeTotal };
+
+  const maxStart = Math.max(0, safeTotal - safeHeight);
+  let start = Math.max(0, Math.min(maxStart, (Number(cursor) || 0) - pad));
+  let end = Math.min(safeTotal, start + safeHeight);
+  if ((Number(cursor) || 0) >= end) {
+    end = Math.min(safeTotal, (Number(cursor) || 0) + pad + 1);
+    start = Math.max(0, end - safeHeight);
+  }
+  if ((Number(cursor) || 0) < start) {
+    start = Math.max(0, (Number(cursor) || 0) - pad);
+    end = Math.min(safeTotal, start + safeHeight);
+  }
+  return { start, end };
+}


### PR DESCRIPTION
### Motivation
- Remove fragile single-letter hotkeys and make download interactions explicit and safe for text contexts. 
- Allow flexible download manifests where some format IDs may intentionally be missing without blocking completion. 
- Replace freeform tag entry with a curated, fast multi-select so tags are consistent and discoverable. 

### Description
- Rebound download step controls: `Ctrl+P` toggles paste mode (and finishes/parses when used again in paste mode) and `Ctrl+G` cycles audio channels, and updated help/footer text and paste-mode behavior in `scripts/ui/init-wizard.mjs`. 
- Relaxed download validation: missing per-format IDs no longer block progress and are surfaced as non-fatal warnings via `downloadWarnings(...)`, while structural checks (numeric `bitDepth`/`sampleRate`, valid `channels`) and tag selection remain enforced. 
- Removed the interactive `sampleLength` input and now emit `metadata.sampleLength: 'AUTO'` in generated output without prompting. 
- Added a filterable multi-select tags picker sourced from `scripts/data/tags.txt` (one tag per line) with type-to-filter, up/down/space selection, and required-at-least-one selection enforced. 
- Implemented a shared rolodex window helper in `scripts/ui/rolodex.mjs` and applied scrolling window rendering (ellipsis indicators) to long lists in the wizard (buckets, credits, download rows, tags) and the dashboard palette/menu to prevent off-screen selection. 
- Minor input-sanitization improvements to prevent escape-like bracket-tilde sequences from polluting text inputs. 

### Testing
- `node --check scripts/ui/init-wizard.mjs` — passed. 
- `node --check scripts/ui/dashboard.mjs` — passed. 
- `node --check scripts/ui/rolodex.mjs` — passed. 
- `npm run smoke:dex-init` — smoke run executed and reported success during development.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69991c2e23fc8327b11f3f1d1ea663bf)