### PR TITLE
Fix sidebar Overview layout, series image wiring, and bucket badges

### DIFF
--- a/assets/css/dex.css
+++ b/assets/css/dex.css
@@ -1203,82 +1203,106 @@ div.sqs-add-to-cart-button-inner {
 }
 
 /* Overview row refresh (CLI parity) */
-.dex-overview .dex-overview-row {
+.dex-overview .dex-overview-grid {
   display: grid;
   grid-template-columns: 1fr auto 1fr;
   gap: 12px;
-  align-items: center;
+  align-items: start;
   width: 100%;
 }
 
 @media (max-width: 640px) {
-  .dex-overview .dex-overview-row {
+  .dex-overview .dex-overview-grid {
     grid-template-columns: 1fr;
+  }
+
+  .dex-overview .overview-cell--buckets .overview-badges {
+    justify-content: flex-start;
   }
 }
 
-.dex-overview .dex-overview-lookupValue {
-  font-family: var(--font-heading);
-  font-weight: 700;
-  letter-spacing: 0.02em;
+.dex-overview .overview-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
 }
 
-.dex-overview .dex-overview-lookupLabel,
-.dex-overview .dex-overview-seriesLabel,
-.dex-overview .dex-overview-bucketsLabel {
-  opacity: 0.7;
-  font-size: 12px;
+.dex-overview .overview-top {
   text-transform: uppercase;
 }
 
-.dex-overview .dex-overview-series,
-.dex-overview .dex-overview-buckets {
-  display: flex;
-  flex-direction: column;
+.dex-overview .overview-label {
+  text-transform: uppercase;
+  opacity: 0.72;
+  font-size: 12px;
+  letter-spacing: 0.04em;
 }
 
-.dex-overview .dex-overview-series {
+.dex-overview .overview-lookup {
+  font-family: var(--font-heading);
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  font-size: 14px;
+  line-height: 1.1;
+}
+
+.dex-overview .overview-series,
+.dex-overview .overview-cell--buckets {
+  display: flex;
+}
+
+.dex-overview .overview-series {
+  align-items: center;
+  justify-content: center;
+}
+
+.dex-overview .overview-cell--series {
   align-items: center;
 }
 
-.dex-overview .dex-overview-buckets {
+.dex-overview .overview-cell--buckets {
   align-items: flex-end;
 }
 
-.dex-overview .dex-overview-seriesMark {
+.dex-overview .overview-series-img {
   width: 56px;
   height: 32px;
+  object-fit: contain;
+  display: block;
   border-radius: 10px;
-  background-image: var(--dex-series-url);
-  background-size: contain;
-  background-repeat: no-repeat;
-  background-position: center;
-  border: 1px solid var(--dex-border);
 }
 
-.dex-overview .dex-overview-badges {
+.dex-overview .overview-badges {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
   justify-content: flex-end;
 }
 
-.dex-overview .dex-overview-badges .badge {
+.dex-overview .overview-badges .badge {
   min-width: 22px;
   text-align: center;
   border-radius: 999px;
   padding: 2px 8px;
+  font-size: 12px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
 }
 
-.dex-overview .dex-overview-badges .badge.unavailable {
+.dex-overview .overview-badges .badge.unavailable {
   display: inline-flex;
   opacity: 0.55;
   border: 1px solid var(--dex-border);
   background: transparent;
 }
 
-.dex-overview .dex-overview-badges .badge.available {
+.dex-overview .overview-badges .badge.available {
   opacity: 1;
   border: 1px solid var(--dex-border-strong);
   background: var(--dex-accent, rgba(120, 170, 255, 0.22));
+}
+
+.dex-overview .badge.unavailable {
+  display: inline-flex !important;
 }

--- a/docs/assets/dex-sidebar.js
+++ b/docs/assets/dex-sidebar.js
@@ -3,12 +3,6 @@
   window.__dexSidebarRuntimeBound = true;
 
   const ALL_BUCKETS = ['A', 'B', 'C', 'D', 'E', 'X'];
-  const SERIES_URLS = {
-    dex: 'url("https://dexdsl.org/assets/series/dex.png")',
-    index: 'url("https://dexdsl.org/assets/series/index.png")',
-    dexfest: 'url("https://dexdsl.org/assets/series/dexfest.png")',
-  };
-
   const normalizeBuckets = (pageBuckets) => (Array.isArray(pageBuckets) ? pageBuckets : []);
 
   const buildBucketsHtml = (pageBuckets) => {
@@ -19,14 +13,6 @@
         return `<span class="badge ${cls}">${bucket}</span>`;
       })
       .join('');
-  };
-
-  const normalizeSeries = (series) => {
-    const raw = String(series || 'dex').toLowerCase();
-    const key = raw === 'index' ? 'index' : raw;
-    if (key === 'index') return { seriesKey: 'index', seriesUrl: SERIES_URLS.index };
-    if (key === 'dexfest') return { seriesKey: 'dexfest', seriesUrl: SERIES_URLS.dexfest };
-    return { seriesKey: 'dex', seriesUrl: SERIES_URLS.dex };
   };
 
   const parseJsonScript = (id) => {
@@ -168,20 +154,24 @@
 
     const lookup = page.lookupNumber || '';
     const badgesHtml = buildBucketsHtml(page.buckets);
-    const { seriesKey, seriesUrl } = normalizeSeries(page.series);
+    const seriesUrl = String(page.specialEventImage || '').trim();
     render('.dex-overview', 'Overview', `
-      <div class="dex-overview-row">
-        <div class="dex-overview-lookup">
-          <div class="dex-overview-lookupValue">#${lookup}</div>
-          <div class="dex-overview-lookupLabel">Lookup #</div>
+      <div class="dex-overview-grid" role="group" aria-label="Overview">
+        <div class="overview-cell overview-cell--lookup">
+          <div class="overview-top overview-lookup">#${lookup}</div>
+          <div class="overview-bottom overview-label">LOOKUP #</div>
         </div>
-        <div class="dex-overview-series" data-series="${seriesKey}">
-          <div class="dex-overview-seriesMark" style="--dex-series-url:${seriesUrl}"></div>
-          <div class="dex-overview-seriesLabel">Series</div>
+
+        <div class="overview-cell overview-cell--series">
+          <div class="overview-top overview-series">
+            <img class="overview-series-img" src="${seriesUrl}" alt="Series" />
+          </div>
+          <div class="overview-bottom overview-label">SERIES</div>
         </div>
-        <div class="dex-overview-buckets">
-          <div class="dex-overview-badges">${badgesHtml}</div>
-          <div class="dex-overview-bucketsLabel">Buckets</div>
+
+        <div class="overview-cell overview-cell--buckets">
+          <div class="overview-top overview-badges">${badgesHtml}</div>
+          <div class="overview-bottom overview-label">BUCKETS</div>
         </div>
       </div>
     `);

--- a/scripts/dex.mjs
+++ b/scripts/dex.mjs
@@ -64,7 +64,7 @@ function mapSeriesToImage(series) {
   if (series === 'dex') return '/assets/series/dex.png';
   if (series === 'inDex') return '/assets/series/index.png';
   if (series === 'dexFest') return '/assets/series/dexfest.png';
-  return null;
+  return '/assets/series/dex.png';
 }
 
 function iframeFor(url) {
@@ -87,7 +87,9 @@ async function collectInitData(opts, slugArg) {
     const videoUrl = base.video?.dataUrl || 'https://player.vimeo.com/video/123456789';
     const seedCredits = base.creditsData || base.sidebarPageConfig?.credits;
     const sidebar = {
-      lookupNumber: lookup, buckets: base.sidebarPageConfig?.buckets || ['A'], specialEventImage: base.sidebarPageConfig?.specialEventImage || null,
+      lookupNumber: lookup,
+      buckets: base.sidebarPageConfig?.buckets || ['A'],
+      specialEventImage: base.sidebarPageConfig?.specialEventImage || mapSeriesToImage(base.series || 'dex'),
       attributionSentence: base.sidebarPageConfig?.attributionSentence || 'Attribution',
       credits: defaultCredits(seedCredits),
       fileSpecs: { bitDepth: 24, sampleRate: 48000, channels: 'stereo', staticSizes: { A: '', B: '', C: '', D: '', E: '', X: '' } },

--- a/scripts/ui/init-wizard.mjs
+++ b/scripts/ui/init-wizard.mjs
@@ -9,6 +9,12 @@ import { computeWindow } from './rolodex.mjs';
 
 const CHANNELS = ['mono', 'stereo', 'multichannel'];
 const SERIES_OPTIONS = ['dex', 'inDex', 'dexFest'];
+function mapSeriesToImage(series) {
+  if (series === 'dex') return '/assets/series/dex.png';
+  if (series === 'inDex') return '/assets/series/index.png';
+  if (series === 'dexFest') return '/assets/series/dexfest.png';
+  return '/assets/series/dex.png';
+}
 const LAST_CACHE = '.dex-last.json';
 
 function iframeFor(url) { return `<iframe src="${url}" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>`; }
@@ -265,7 +271,7 @@ export function InitWizard({ templateArg, outDirDefault, onCancel, onDone }) {
           year: Number(form.creditsData.year), season: form.creditsData.season, location: form.creditsData.location,
         };
         const sidebar = {
-          lookupNumber: form.lookupNumber, buckets: form.buckets, specialEventImage: null, attributionSentence: form.attributionSentence,
+          lookupNumber: form.lookupNumber, buckets: form.buckets, specialEventImage: mapSeriesToImage(form.series), attributionSentence: form.attributionSentence,
           credits: { artist: creditsData.artist, artistAlt: creditsData.artistAlt, instruments: creditsData.instruments, video: { director: creditsData.video.director, cinematography: creditsData.video.cinematography, editing: creditsData.video.editing }, audio: { recording: creditsData.audio.recording, mix: creditsData.audio.mix, master: creditsData.audio.master }, year: creditsData.year, season: creditsData.season, location: creditsData.location },
           fileSpecs: { bitDepth: Number(form.downloadData.fileSpecs.bitDepth) || 24, sampleRate: Number(form.downloadData.fileSpecs.sampleRate) || 48000, channels: form.downloadData.fileSpecs.channels, staticSizes: form.downloadData.fileSpecs.staticSizes },
           metadata: { sampleLength: 'AUTO', tags: safeList(form.downloadData.metadata.tagsSelected) },

--- a/scripts/ui/update-wizard.mjs
+++ b/scripts/ui/update-wizard.mjs
@@ -11,6 +11,12 @@ import { computeWindow } from './rolodex.mjs';
 const CHECKS = ['Title', 'Description', 'Lookup #', 'Video URL', 'Series', 'Buckets', 'License sentence', 'Instruments', 'Credits / People', 'Downloads', 'File Specs', 'Metadata'];
 
 function toPeople(list = []) { return list.map((name) => ({ name, links: [] })); }
+function mapSeriesToImage(series) {
+  if (series === 'dex') return '/assets/series/dex.png';
+  if (series === 'inDex') return '/assets/series/index.png';
+  if (series === 'dexFest') return '/assets/series/dexfest.png';
+  return '/assets/series/dex.png';
+}
 
 export function UpdateWizard({ initialSlug = '', onDone, onCancel }) {
   const [entries, setEntries] = useState([]);
@@ -61,7 +67,10 @@ export function UpdateWizard({ initialSlug = '', onDone, onCancel }) {
     if (selectedSections.includes('Description')) entry.descriptionText = form.descriptionText;
     if (selectedSections.includes('Lookup #')) entry.sidebarPageConfig.lookupNumber = form.lookupNumber;
     if (selectedSections.includes('Video URL')) entry.video = { mode: 'url', dataUrl: form.videoUrl, dataHtml: `<iframe src="${form.videoUrl}" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>` };
-    if (selectedSections.includes('Series')) entry.series = form.series;
+    if (selectedSections.includes('Series')) {
+      entry.series = form.series;
+      entry.sidebarPageConfig.specialEventImage = mapSeriesToImage(form.series);
+    }
     if (selectedSections.includes('Buckets')) { entry.selectedBuckets = form.buckets; entry.sidebarPageConfig.buckets = form.buckets; }
     if (selectedSections.includes('License sentence')) entry.sidebarPageConfig.attributionSentence = form.attributionSentence;
     if (selectedSections.includes('Instruments')) entry.sidebarPageConfig.credits.instruments = form.instruments;


### PR DESCRIPTION
### Motivation

- Make the Sidebar "Overview" card match the known-good snapshot: two-row / three-column layout with a visible card title, all six buckets shown, and the series image loading correctly from same-origin assets.
- Fix the root cause of missing series images by ensuring CLI/runtime consistently provide a valid site-root-relative `specialEventImage` URL instead of relying on fragile background-image wiring to an external origin.

### Description

- Reworked runtime overview rendering in `docs/assets/dex-sidebar.js` to use `render('.dex-overview', 'Overview', ...)` and emit a 2-row/3-column grid with explicit lookup, series (`<img src=

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69996f2b6d248327afe319267b93eb3a)