### PR TITLE
Align sidebar overview markup and fix series image origin

### DIFF
--- a/docs/static/versioned-site-css/63956a55e99f9772a8cd1742/771/5c5a519771c10ba3470d8101/63956a55e99f9772a8cd175d/1741/site.css
+++ b/docs/static/versioned-site-css/63956a55e99f9772a8cd1742/771/5c5a519771c10ba3470d8101/63956a55e99f9772a8cd175d/1741/site.css
@@ -181,3 +181,54 @@ dex_css_aug27_25 #block-yui_3_17_2_1_1727041385374_174014 .sqs-button-element--p
 ).sqs-fullwidth{width:100% !important;justify-content:center !important}:where(.sqs-block-button,.sqs-block-form,.summary-block,.newsletter-block) :is(a.sqs-button-element--secondary,
       button.sqs-button-element--secondary,
       input[type="submit"].sqs-button-element--secondary){display:inline-flex !important;align-items:center !important;justify-content:center !important;width:100% !important;max-width:none !important;font-family:'Typefesse',sans-serif !important;font-weight:800 !important;font-size:clamp(18px,2.4vw,26px) !important;line-height:1.05 !important;letter-spacing:0 !important;padding:16px 22px !important;background:#111 !important;color:rgba(255,255,255,.86) !important;border:1px solid rgba(0,0,0,.15) !important;border-radius:4px !important;text-transform:uppercase !important;text-decoration:none !important;-webkit-font-smoothing:antialiased;font-variant-ligatures:common-ligatures discretionary-ligatures contextual;font-feature-settings:"liga" 1,"dlig" 1,"calt" 1,"ss01" 1,"salt" 1,"rlig" 1}.sqs-block-button-element--large.sqs-button-element--secondary{font-size:clamp(19px,2.8vw,28px) !important;padding:18px 24px !important}.sqs-block-button-element--medium.sqs-button-element--secondary{font-size:clamp(18px,2.4vw,26px) !important;padding:16px 22px !important}.sqs-block-button-element--small.sqs-button-element--secondary{font-size:clamp(16px,2vw,22px) !important;padding:14px 18px !important}@media (hover:hover){:where(.sqs-block-button,.sqs-block-form,.summary-block,.newsletter-block) :is(a.sqs-button-element--secondary,button.sqs-button-element--secondary){transition:transform .16s cubic-bezier(.2,.7,.2,1),box-shadow .22s ease,color .18s ease}:where(.sqs-block-button,.sqs-block-form,.summary-block,.newsletter-block) :is(a.sqs-button-element--secondary,button.sqs-button-element--secondary):hover{transform:translatey(-1px);box-shadow:0 10px 26px rgba(0,0,0,.12);color:#fff !important}}.sqs-button-element--secondary:focus-visible{outline:none !important;box-shadow:0 0 0 2px rgba(255,255,255,.35),0 0 0 6px rgba(0,0,0,.18) !important}header.header,.Header{border-radius:4px !important;overflow:hidden}.announcement-bar,.header-announcement-bar-wrapper{border-radius:4px !important;overflow:hidden}:root{--float-gap:16px;--card-radius:4px;--card-max:9999px}.sqs-announcement-bar,.announcement-bar,.header-announcement-bar-wrapper{position:sticky;top:-16px;max-width:var(--card-max);width:min(96vw,var(--card-max));margin:var(--float-gap) auto -1px;border-radius:4px !important;overflow:hidden;z-index:101}:root{--hdr-trim-top:2px;--hdr-trim-bottom:2px}header.header,.Header{position:sticky;top:2px !important;max-width:var(--card-max);width:min(96vw,var(--card-max));margin:-1px auto 24px;border-radius:4px !important;overflow:visible;z-index:100}@media (max-width:900px){.Header-burger,.header-burger{height:32px !important;padding:0 !important;margin-top:-34px}header.header,.Header{margin-top:2px !important;max-height:120px !important;border-radius:4px !important}}.dex-modal[hidden]{display:none !important}@media (min-width:901px){.Header-inner::before,.header-inner::before{content:none !important;border-radius:4px !important}}@media (min-width:901px){.Header{position:sticky;top:2px;border-radius:4px !important}.Header::before{content:"";position:absolute;left:0;right:0;top:0;height:100% !important;border-radius:4px;pointer-events:none;z-index:0}.Header>*{position:relative;z-index:1}}:root{--dex-announce-pad-y:0px}.header-announcement-bar-wrapper{background:none !important;border-radius:4px !important}.sqs-announcement-bar,.announcement-bar{position:relative;background:none !important;overflow:hidden !important}.sqs-announcement-bar::before,.announcement-bar::before{border-radius:4px !important;content:"";position:absolute;inset:0;background:linear-gradient(90deg,#bf0fff,#ff6b0f);background-size:300% 100%;animation:dexAnnounce 6s linear infinite;pointer-events:none;z-index:0}.sqs-announcement-bar>*,.announcement-bar>*{position:relative;z-index:1}.sqs-announcement-bar :is(.sqs-announcement-bar-content, .content, .inner),.announcement-bar :is(.announcement-bar-content, .content, .inner){padding:var(--dex-announce-pad-y) 0px !important;line-height:.2 !important}.sqs-announcement-bar :is(p, .sqs-announcement-bar-text),.announcement-bar :is(p, .announcement-bar-text){margin:0 !important;font-size:14px !important}@keyframes dexAnnounce{0%{background-position:0% 50%}50%{background-position:100% 50%}100%{background-position:0% 50%}}.header-announcement-bar-wrapper,.sqs-announcement-bar,.announcement-bar{margin-bottom:12px !important}.header-announcement-bar-wrapper::after,.sqs-announcement-bar::after,.announcement-bar::after{content:"";display:block;height:-8px}@media (min-width:901px){.Header-inner::before,.header-inner::before{content:"" !important;border-radius:4px !important}}.Header::before{content:none !important;border-radius:4px !important}header.header,.Header{overflow:visible !important;border-radius:4px !important}.header-announcement-bar-wrapper,.sqs-announcement-bar,.announcement-bar{overflow:visible !important}.header-announcement-bar-wrapper,.header-background-solid,.header-dropshadow{border-radius:4px !important}:root{--dex-accent:#ff1910}.header-nav a,.header-nav-item>a,.Header .header-nav a,.header-nav .header-nav-folder-content a{position:relative;display:inline-block;font-family:'Courier New',monospace !important;font-weight:600;color:#232323 !important;text-decoration:none !important;transition:color .2s ease,transform .2s ease}.header-nav a::after,.header-nav-item>a::after,.Header .header-nav a::after,.header-nav .header-nav-folder-content a::after{content:"";position:absolute;left:0;bottom:0;width:100%;height:2px;background:linear-gradient(90deg,var(--dex-accent),#ff9810);transform:scalex(0);transform-origin:right;transition:transform .3s ease}.header-nav a:hover,.header-nav a:focus-visible,.header-nav-item>a:hover,.header-nav-item>a:focus-visible,.Header .header-nav a:hover,.Header .header-nav a:focus-visible,.header-nav .header-nav-folder-content a:hover,.header-nav .header-nav-folder-content a:focus-visible{transform:translatey(-2px);color:var(--dex-accent) !important}.header-nav a:hover::after,.header-nav a:focus-visible::after,.header-nav-item>a:hover::after,.header-nav-item>a:focus-visible::after,.Header .header-nav a:hover::after,.Header .header-nav a:focus-visible::after,.header-nav .header-nav-folder-content a:hover::after,.header-nav .header-nav-folder-content a:focus-visible::after{transform-origin:left;transform:scalex(1)}.header-nav a:hover,.header-nav a:focus-visible{transform:none}:root{--hdr-icon:28px;--hdr-radius:var(--radius-sm,4px);--glass-bg:rgba(255,255,255,.55);--glass-bg-hover:rgba(255,255,255,.82);--glass-border:rgba(255,255,255,.35);--glass-border-hover:rgba(0,0,0,.18)}.header-actions-action--cta{order:1 !important}.Header-social,.header-actions-action--social{order:2 !important}header.header :is(.Header-social a, .header-actions-action--social a){width:var(--hdr-icon);height:var(--hdr-icon);display:inline-flex;align-items:center;justify-content:center;border-radius:var(--hdr-radius);background:var(--glass-bg);border:1px solid var(--glass-border);-webkit-backdrop-filter:blur(6px);backdrop-filter:blur(6px);box-shadow:0 2px 6px rgba(0,0,0,.1);color:var(--dex-text,#000);line-height:1;text-decoration:none;margin-left:8px;transition:transform .18s ease,box-shadow .22s ease,background .18s ease,color .18s ease,border-color .18s ease}header.header :is(.Header-social a svg, .header-actions-action--social a svg){width:1rem;height:1rem;fill:currentColor !important}@media (hover:hover){header.header :is(.Header-social a, .header-actions-action--social a):hover{transform:translatey(-1px);background:var(--glass-bg-hover);border-color:var(--glass-border-hover);box-shadow:0 8px 18px rgba(0,0,0,.14)}}header.header .Header-social a[href*="youtube"],header.header .header-actions-action--social a[href*="youtube"]{--brand-bg:red;--brand-fg:#fff}header.header .Header-social a[href*="instagram"],header.header .header-actions-action--social a[href*="instagram"]{--brand-bg:radial-gradient(circle at 30% 107%,#fdf497 0%,#fd5949 45%,#d6249f 60%,#285aeb 90%);--brand-fg:#fff}header.header .Header-social a[href*="tiktok"],header.header .header-actions-action--social a[href*="tiktok"]{--brand-bg:#000;--brand-fg:#fff}header.header .Header-social a[href*="twitter"],header.header .Header-social a[href*="x.com"],header.header .header-actions-action--social a[href*="twitter"],header.header .header-actions-action--social a[href*="x.com"]{--brand-bg:#1da1f2;--brand-fg:#fff}@media (hover:hover){header.header .Header-social a:hover,header.header .header-actions-action--social a:hover{background:var(--brand-bg,var(--glass-bg-hover));color:var(--brand-fg,#fff) !important;border-color:transparent}}header.header :is(.Header-social a, .header-actions-action--social a):focus-visible{outline:none;box-shadow:0 0 0 2px rgba(255,255,255,.85),0 0 0 4px rgba(0,0,0,.25)}@media (max-width:900px){:root{--hdr-icon:26px}}header.header .Header-social a,header.header .header-actions-action--social a{color:#232323 !important}
+.dex-overview{
+  display:grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: 12px;
+  align-items:start;
+}
+
+.dex-overview .overview-item{
+  display:flex;
+  flex-direction:column;
+  gap: 6px;
+  min-width:0;
+}
+
+.dex-overview .overview-item:nth-child(1){ align-items:flex-start; }
+.dex-overview .overview-item:nth-child(2){ align-items:center; }
+.dex-overview .overview-item:nth-child(3){ align-items:flex-end; }
+
+@media (max-width: 640px){
+  .dex-overview{ grid-template-columns: 1fr; }
+  .dex-overview .overview-item:nth-child(3){ align-items:flex-start; }
+  .dex-overview .overview-badges{ justify-content:flex-start; }
+}
+
+.dex-overview .overview-lookup{
+  font-family: var(--font-heading);
+  font-weight: 700;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+}
+
+.dex-overview .overview-series-img{
+  width:56px;
+  height:32px;
+  object-fit:contain;
+  display:block;
+  border-radius:10px;
+}
+
+.dex-overview .overview-badges{ display:flex; flex-wrap:wrap; gap:6px; justify-content:flex-end; }
+.dex-overview .overview-badges .badge.unavailable{
+  display:inline-flex !important;
+  opacity:.6;
+  border:1px solid var(--dex-border);
+  background:transparent;
+}
+.dex-overview .overview-badges .badge.available{
+  opacity:1;
+  border:1px solid var(--dex-border-strong);
+  background: var(--dex-accent, rgba(120,170,255,.22));
+}


### PR DESCRIPTION
### Motivation
- Make the Sidebar OVERVIEW match the Squarespace snapshot structure (no header and exact class names) and ensure bucket badges are always shown. 
- Ensure the series image is resolved from the script asset origin (so root-relative Squarespace image paths do not leak an incorrect origin).

### Description
- Reworked the overview render in `docs/assets/dex-sidebar.js` to write directly into `.dex-overview` (no `Overview` header) and use exact snapshot class names: `overview-item`, `overview-lookup`, `overview-label`, `overview-badges`, and `overview-series-img`.
- Always render all six buckets using the `ALL_BUCKETS` constant so badges HTML always contains `A,B,C,D,E,X`, with `available`/`unavailable` classes for CSS-driven states; download modal bucket iteration now uses `ALL_BUCKETS` as well.
- Added `getSidebarAssetOrigin()` and `seriesKey()` to compute the `series` image `seriesSrc` from the origin of `dex-sidebar.js` and a small series-to-path mapping `SERIES_PATHS`, then always render the computed `seriesSrc` into the overview image.
- Updated the served stylesheet (`docs/static/versioned-site-css/.../site.css`) with the requested 3-column (desktop) / stacked (mobile) grid and the badge/lookup/series sizing and typography rules to match the snapshot layout.

### Testing
- Ran `node --check docs/assets/dex-sidebar.js` which succeeded.
- Confirmed the entry HTML references the runtime script (`/assets/dex-sidebar.js`) and that the site uses the versioned `site.css` path via `rg`/source checks, which succeeded.
- Started a local static server and attempted a Playwright-driven verification; the page contained `.dex-overview` but `/assets/dex-sidebar.js` was not served from this repo layout (404), so full hydrated checks for `.overview-series-img` and badge visual states could not be completed (partial checks captured `.dex-overview` existence and produced screenshots).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999775f0ee08327ae9b4904c7c43777)